### PR TITLE
feat: add interactive setup mode (-i flag)

### DIFF
--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -1,0 +1,79 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// promptInteractive presents a series of prompts on stderr and merges the
+// user's answers into c.  It is only called when --interactive / -i is set.
+// The current values in c are shown as defaults; pressing Enter keeps them.
+func promptInteractive(c *Config) error {
+	s := bufio.NewScanner(os.Stdin)
+
+	fmt.Fprintln(os.Stderr, "\n=== Interactive Setup ===")
+	fmt.Fprintln(os.Stderr, "Press Enter to accept the value shown in [brackets].\n")
+
+	// ---- Image override ------------------------------------------------
+	fmt.Fprintf(os.Stderr, "Image [%s]: ", c.Image)
+	if s.Scan() {
+		if v := strings.TrimSpace(s.Text()); v != "" {
+			c.Image = v
+		}
+	}
+
+	// ---- Network mode --------------------------------------------------
+	defaultNetwork := c.NetworkMode
+	if defaultNetwork == "" {
+		defaultNetwork = "host"
+	}
+	fmt.Fprintf(os.Stderr, "Network mode (host/bridge/none) [%s]: ", defaultNetwork)
+	if s.Scan() {
+		if v := strings.TrimSpace(s.Text()); v != "" {
+			switch v {
+			case "host", "bridge", "none":
+				c.NetworkMode = v
+			default:
+				fmt.Fprintf(os.Stderr, "  Unknown network mode %q — keeping %q\n", v, defaultNetwork)
+				c.NetworkMode = defaultNetwork
+			}
+		} else {
+			c.NetworkMode = defaultNetwork
+		}
+	}
+
+	// ---- Volume mounts -------------------------------------------------
+	fmt.Fprintln(os.Stderr, "Volume mounts (format: host_path:container_path, e.g. $PWD:/workspace):")
+	for {
+		label := "  Add volume mount"
+		if len(c.ExtraBinds) > 0 {
+			label = "  Add another volume mount"
+		}
+		fmt.Fprintf(os.Stderr, "%s (empty to skip): ", label)
+		if !s.Scan() {
+			break
+		}
+		v := strings.TrimSpace(s.Text())
+		if v == "" {
+			break
+		}
+		c.ExtraBinds = append(c.ExtraBinds, v)
+	}
+
+	// ---- Entrypoint override -------------------------------------------
+	fmt.Fprintf(os.Stderr, "Entrypoint override (empty to use container default): ")
+	if s.Scan() {
+		if v := strings.TrimSpace(s.Text()); v != "" {
+			c.Entrypoint = v
+		}
+	}
+
+	if err := s.Err(); err != nil {
+		return fmt.Errorf("reading interactive input: %w", err)
+	}
+
+	fmt.Fprintln(os.Stderr)
+	return nil
+}

--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -14,7 +14,7 @@ func promptInteractive(c *Config) error {
 	s := bufio.NewScanner(os.Stdin)
 
 	fmt.Fprintln(os.Stderr, "\n=== Interactive Setup ===")
-	fmt.Fprintln(os.Stderr, "Press Enter to accept the value shown in [brackets].\n")
+	fmt.Fprintln(os.Stderr, "Press Enter to accept the value shown in [brackets].")
 
 	// ---- Image override ------------------------------------------------
 	fmt.Fprintf(os.Stderr, "Image [%s]: ", c.Image)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,6 +27,11 @@ type Config struct {
 	TokenTTL        time.Duration
 	NoCleanup       bool
 	Skills          []string
+	// Interactive setup fields (populated by -i prompt or future flags)
+	Interactive bool
+	NetworkMode string   // network mode for the container (default: "host")
+	ExtraBinds  []string // additional volume mounts in "host:container[:opts]" format
+	Entrypoint  string   // override container entrypoint
 }
 
 var cfg Config
@@ -85,6 +90,10 @@ func init() {
 Repeatable; each skill's SKILL.md is fetched from raw.githubusercontent.com and
 installed to /root/.copilot/skills/<name>/ inside the container.
 Requires --build. Example: --skill lobbi-docs/claude/kubernetes`)
+	rootCmd.Flags().BoolVarP(&cfg.Interactive, "interactive", "i", false,
+		"Prompt for runtime parameters (image, network mode, volume mounts, entrypoint)\n"+
+			"before launching the container.  Non-interactive behaviour is preserved when\n"+
+			"this flag is not set.")
 }
 
 func run(cmd *cobra.Command, _ []string) error {
@@ -106,6 +115,13 @@ func run(cmd *cobra.Command, _ []string) error {
 	}
 	if cfg.Pull && cfg.Build {
 		return fmt.Errorf("--pull and --build are mutually exclusive: choose one")
+	}
+
+	// ---- Interactive setup prompt -------------------------------------
+	if cfg.Interactive {
+		if err := promptInteractive(&cfg); err != nil {
+			return fmt.Errorf("interactive setup failed: %w", err)
+		}
 	}
 
 	// ---- signal handling -----------------------------------------------
@@ -220,8 +236,11 @@ func run(cmd *cobra.Command, _ []string) error {
 	fmt.Println("Press Ctrl+C to exit and trigger cleanup.")
 
 	runCfg := container.RunConfig{
-		Image:      cfg.Image,
-		Kubeconfig: cfg.OutKubeconfig,
+		Image:       cfg.Image,
+		Kubeconfig:  cfg.OutKubeconfig,
+		ExtraBinds:  cfg.ExtraBinds,
+		NetworkMode: cfg.NetworkMode,
+		Entrypoint:  cfg.Entrypoint,
 	}
 
 	if err := ctr.Run(ctx, runCfg); err != nil {

--- a/internal/container/api.go
+++ b/internal/container/api.go
@@ -131,22 +131,35 @@ func (a *apiClient) Run(ctx context.Context, cfg RunConfig) error {
 
 	ghToken := os.Getenv("GH_TOKEN")
 
+	binds := []string{absKubeconfig + ":/root/.kube/config:ro"}
+	binds = append(binds, cfg.ExtraBinds...)
+
+	networkMode := cfg.NetworkMode
+	if networkMode == "" {
+		networkMode = "host"
+	}
+
+	ctrCfg := &container.Config{
+		Image:        cfg.Image,
+		Tty:          true,
+		OpenStdin:    true,
+		StdinOnce:    true,
+		AttachStdin:  true,
+		AttachStdout: true,
+		AttachStderr: true,
+		Env:          []string{"GH_TOKEN=" + ghToken},
+	}
+	if cfg.Entrypoint != "" {
+		ctrCfg.Entrypoint = []string{cfg.Entrypoint}
+	}
+
 	// ---- Create (no AutoRemove — we clean up ourselves) -----------------
 	createResp, err := a.cli.ContainerCreate(
 		ctx,
-		&container.Config{
-			Image:        cfg.Image,
-			Tty:          true,
-			OpenStdin:    true,
-			StdinOnce:    true,
-			AttachStdin:  true,
-			AttachStdout: true,
-			AttachStderr: true,
-			Env:          []string{"GH_TOKEN=" + ghToken},
-		},
+		ctrCfg,
 		&container.HostConfig{
-			NetworkMode: "host",
-			Binds:       []string{absKubeconfig + ":/root/.kube/config:ro"},
+			NetworkMode: container.NetworkMode(networkMode),
+			Binds:       binds,
 		},
 		nil, nil, "",
 	)

--- a/internal/container/client.go
+++ b/internal/container/client.go
@@ -11,8 +11,11 @@ import (
 
 // RunConfig holds what the container runner needs to start the container.
 type RunConfig struct {
-	Image      string
-	Kubeconfig string
+	Image       string
+	Kubeconfig  string
+	ExtraBinds  []string // additional volume mounts in "host:container[:opts]" format
+	NetworkMode string   // network mode ("host", "bridge", "none", …); empty defaults to "host"
+	Entrypoint  string   // override container entrypoint; empty = use image default
 }
 
 // Client is the interface both the Docker-SDK backend and the exec fallback

--- a/internal/container/exec.go
+++ b/internal/container/exec.go
@@ -80,17 +80,31 @@ func (e *execClient) Run(ctx context.Context, cfg RunConfig) error {
 		return fmt.Errorf("resolving kubeconfig path: %w", err)
 	}
 
+	networkMode := cfg.NetworkMode
+	if networkMode == "" {
+		networkMode = "host"
+	}
+
 	args := []string{
 		"run",
 		"--rm",
 		"-it",
-		"--network=host",
+		"--network=" + networkMode,
 		"-v", fmt.Sprintf("%s:/root/.kube/config:ro", absKubeconfig),
 		// Forward GH_TOKEN without reading its value in Go — both Docker and
 		// Podman resolve the value from the calling process env when no
 		// '=value' is appended.
 		"-e", "GH_TOKEN",
 	}
+
+	for _, bind := range cfg.ExtraBinds {
+		args = append(args, "-v", bind)
+	}
+
+	if cfg.Entrypoint != "" {
+		args = append(args, "--entrypoint", cfg.Entrypoint)
+	}
+
 	args = append(args, cfg.Image)
 
 	cmd := exec.Command(e.runtime, args...)


### PR DESCRIPTION
## Summary

- Adds `--interactive` / `-i` flag that presents a pre-launch configuration prompt before starting the container.
- The prompt lets the user configure at runtime: **image override**, **network mode** (`host`/`bridge`/`none`), **arbitrary volume mounts** (`host_path:container_path[:opts]`), and an optional **entrypoint override**.
- Non-interactive (current) behaviour is fully preserved when `-i` is not passed.
- `RunConfig` gains `ExtraBinds []string`, `NetworkMode string`, and `Entrypoint string` fields; both the Docker SDK backend (`internal/container/api.go`) and the exec CLI fallback (`internal/container/exec.go`) honour them.
- Prompt logic lives in the new `cmd/interactive.go` file.

## Usage

```sh
# Launch with interactive setup
kpil -i

# Example session:
# === Interactive Setup ===
# Press Enter to accept the value shown in [brackets].
#
# Image [ghcr.io/qjoly/kpil:latest]:               ← press Enter to keep
# Network mode (host/bridge/none) [host]: bridge
# Volume mounts (format: host_path:container_path, e.g. $PWD:/workspace):
#   Add volume mount (empty to skip): /home/user/project:/workspace
#   Add another volume mount (empty to skip):       ← press Enter to finish
# Entrypoint override (empty to use container default): /bin/bash
```

Closes the *Interactive setup mode (`-i`)* item in TODO.md.