### PR TITLE
fix(docker): correct arm64 copilot binary via multi-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,34 @@
 #     kpil:latest
 # ---------------------------------------------------------------------------
 
+# ---------------------------------------------------------------------------
+# Stage 1: download the GitHub Copilot CLI binary for the TARGET architecture.
+#
+# Running this stage FROM --platform=$BUILDPLATFORM (the CI host, always
+# amd64) while declaring ARG TARGETARCH causes BuildKit to correctly inject
+# the target architecture (e.g. arm64) rather than the host's architecture.
+# Without this stage, BuildKit's native cross-compilation mode sets TARGETARCH
+# to the *execution* platform (amd64), so the arm64 image would get an x64
+# binary.
+# ---------------------------------------------------------------------------
+FROM --platform=$BUILDPLATFORM alpine:3.21 AS copilot-downloader
+ARG TARGETARCH=amd64
+RUN apk add --no-cache curl \
+    && case "${TARGETARCH}" in \
+         amd64) CLI_ARCH="x64" ;; \
+         arm64) CLI_ARCH="arm64" ;; \
+         *)     CLI_ARCH="x64" ;; \
+       esac \
+    && echo "  Downloading GitHub Copilot CLI (linux-${CLI_ARCH})…" \
+    && curl -fsSL \
+        "https://github.com/github/copilot-cli/releases/download/v1.0.35/copilot-linux-${CLI_ARCH}.tar.gz" \
+        | tar -xz -C /usr/local/bin copilot \
+    && chmod +x /usr/local/bin/copilot \
+    && echo "  Installed to /usr/local/bin/copilot"
+
+# ---------------------------------------------------------------------------
+# Stage 2: main image
+# ---------------------------------------------------------------------------
 FROM node:25-slim
 
 # ---------------------------------------------------------------------------
@@ -120,31 +148,10 @@ RUN --mount=type=bind,source=.,target=/build-ctx \
     fi
 
 # ---------------------------------------------------------------------------
-# GitHub Copilot CLI — downloaded from the public github/copilot-cli release.
-# No authentication required at build time (public repository).
-#
-# gh v2.91+ ships a built-in `gh copilot` wrapper that looks for a `copilot`
-# binary in PATH and delegates all arguments to it.  We install the binary
-# from github/copilot-cli directly to /usr/local/bin/copilot.
-#
-# Arch mapping (TARGETARCH → tarball suffix):
-#   amd64 → x64   |   arm64 → arm64
-#
-# TARGETARCH is set automatically by buildx in multi-platform builds and
-# defaults to "amd64" for plain `docker build` invocations.
+# GitHub Copilot CLI — copied from the downloader stage above.
+# The binary was fetched for the correct TARGETARCH in stage 1.
 # ---------------------------------------------------------------------------
-ARG TARGETARCH=amd64
-RUN case "${TARGETARCH}" in \
-      amd64) CLI_ARCH="x64" ;; \
-      arm64) CLI_ARCH="arm64" ;; \
-      *)     CLI_ARCH="x64" ;; \
-    esac \
-    && echo "  Downloading GitHub Copilot CLI (linux-${CLI_ARCH})…" \
-    && curl -fsSL \
-        "https://github.com/github/copilot-cli/releases/download/v1.0.35/copilot-linux-${CLI_ARCH}.tar.gz" \
-        | tar -xz -C /usr/local/bin copilot \
-    && chmod +x /usr/local/bin/copilot \
-    && echo "  Installed to /usr/local/bin/copilot"
+COPY --from=copilot-downloader /usr/local/bin/copilot /usr/local/bin/copilot
 
 # ---------------------------------------------------------------------------
 # Entrypoint — safety-net download of the Copilot CLI if absent, then


### PR DESCRIPTION
## Summary

- BuildKit's native cross-compilation mode sets `TARGETARCH` to the *execution* platform (`amd64`) rather than the build target (`arm64`), causing the arm64 image to always receive the x64 `copilot` binary (confirmed via ELF header inspection)
- Introduces a `FROM --platform=$BUILDPLATFORM` downloader stage where BuildKit correctly injects `TARGETARCH=arm64`, then `COPY --from` brings the right binary into the main image
- Also includes the `--platform` CLI flag and `go vet` fix from previous commits

## Test plan

- [ ] CI builds arm64 image: confirm log shows `Downloading GitHub Copilot CLI (linux-arm64)` for the arm64 stage
- [ ] Pull new `edge` image and verify: `docker run --rm --entrypoint=sh ghcr.io/qjoly/kpil:edge -c 'od -A x -t x1z -v /usr/local/bin/copilot | head -2'` → bytes 0x12-0x13 should be `b7 00` (AArch64), not `3e 00` (x86-64)
- [ ] Run `go run main.go --pull --image ghcr.io/qjoly/kpil:edge` on Apple Silicon without `--platform` flag