### PR TITLE
fix(docker): use dpkg --print-architecture for copilot arch detection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,34 +20,6 @@
 #     kpil:latest
 # ---------------------------------------------------------------------------
 
-# ---------------------------------------------------------------------------
-# Stage 1: download the GitHub Copilot CLI binary for the TARGET architecture.
-#
-# Running this stage FROM --platform=$BUILDPLATFORM (the CI host, always
-# amd64) while declaring ARG TARGETARCH causes BuildKit to correctly inject
-# the target architecture (e.g. arm64) rather than the host's architecture.
-# Without this stage, BuildKit's native cross-compilation mode sets TARGETARCH
-# to the *execution* platform (amd64), so the arm64 image would get an x64
-# binary.
-# ---------------------------------------------------------------------------
-FROM --platform=$BUILDPLATFORM alpine:3.21 AS copilot-downloader
-ARG TARGETARCH=amd64
-RUN apk add --no-cache curl \
-    && case "${TARGETARCH}" in \
-         amd64) CLI_ARCH="x64" ;; \
-         arm64) CLI_ARCH="arm64" ;; \
-         *)     CLI_ARCH="x64" ;; \
-       esac \
-    && echo "  Downloading GitHub Copilot CLI (linux-${CLI_ARCH})…" \
-    && curl -fsSL \
-        "https://github.com/github/copilot-cli/releases/download/v1.0.35/copilot-linux-${CLI_ARCH}.tar.gz" \
-        | tar -xz -C /usr/local/bin copilot \
-    && chmod +x /usr/local/bin/copilot \
-    && echo "  Installed to /usr/local/bin/copilot"
-
-# ---------------------------------------------------------------------------
-# Stage 2: main image
-# ---------------------------------------------------------------------------
 FROM node:25-slim
 
 # ---------------------------------------------------------------------------
@@ -148,10 +120,25 @@ RUN --mount=type=bind,source=.,target=/build-ctx \
     fi
 
 # ---------------------------------------------------------------------------
-# GitHub Copilot CLI — copied from the downloader stage above.
-# The binary was fetched for the correct TARGETARCH in stage 1.
+# GitHub Copilot CLI — downloaded from the public github/copilot-cli release.
+#
+# Uses $(dpkg --print-architecture) evaluated inside the target container
+# (arm64 via QEMU in CI) so the correct arch binary is always fetched.
+# TARGETARCH is intentionally avoided: BuildKit's native cross-compilation
+# mode sets it to the *build host* arch rather than the target arch.
 # ---------------------------------------------------------------------------
-COPY --from=copilot-downloader /usr/local/bin/copilot /usr/local/bin/copilot
+RUN ARCH="$(dpkg --print-architecture)" \
+    && case "${ARCH}" in \
+         amd64) CLI_ARCH="x64" ;; \
+         arm64) CLI_ARCH="arm64" ;; \
+         *)     CLI_ARCH="x64" ;; \
+       esac \
+    && echo "  Downloading GitHub Copilot CLI (linux-${CLI_ARCH})…" \
+    && curl -fsSL \
+        "https://github.com/github/copilot-cli/releases/download/v1.0.35/copilot-linux-${CLI_ARCH}.tar.gz" \
+        | tar -xz -C /usr/local/bin copilot \
+    && chmod +x /usr/local/bin/copilot \
+    && echo "  Installed to /usr/local/bin/copilot"
 
 # ---------------------------------------------------------------------------
 # Entrypoint — safety-net download of the Copilot CLI if absent, then


### PR DESCRIPTION
## Summary

The previous `FROM --platform=\$BUILDPLATFORM` multi-stage approach didn't work: BuildKit deduplicates that stage across all target platforms and resolves `TARGETARCH` to the build host arch (`amd64`), so the arm64 image still got the x64 binary.

Root cause confirmed in CI logs:
```
#16 [linux/amd64 copilot-downloader 2/2] RUN ... case "amd64" in
```
One shared step, `TARGETARCH=amd64` for both builds.

Fix: use `$(dpkg --print-architecture)` evaluated inside the QEMU-emulated arm64 container — the same approach already used for `kubectl` and `gh`. It always returns the correct target arch regardless of BuildKit's execution model.

## Test plan

- [ ] CI log for arm64 build shows `Downloading GitHub Copilot CLI (linux-arm64)`
- [ ] `od` check on new `edge` image: bytes 0x12-0x13 = `b7 00` (AArch64)