### PR TITLE
feat: add --platform flag to override OCI platform at runtime

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -34,6 +34,7 @@ type Config struct {
 	NetworkMode string   // network mode for the container (default: "host")
 	ExtraBinds  []string // additional volume mounts in "host:container[:opts]" format
 	Entrypoint  string   // override container entrypoint
+	Platform    string   // OCI platform string e.g. "linux/amd64", "linux/arm64"
 }
 
 var cfg Config
@@ -101,6 +102,9 @@ Requires --build. Example: --skill lobbi-docs/claude/kubernetes`)
 		"Prompt for runtime parameters (image, network mode, volume mounts, entrypoint)\n"+
 			"before launching the container.  Non-interactive behaviour is preserved when\n"+
 			"this flag is not set.")
+	rootCmd.Flags().StringVar(&cfg.Platform, "platform", "",
+		"OCI platform to run (e.g. linux/amd64, linux/arm64). Defaults to the daemon's native platform.\n"+
+			"Use linux/amd64 on Apple Silicon when the image has no arm64 variant.")
 }
 
 func run(cmd *cobra.Command, _ []string) error {
@@ -260,6 +264,7 @@ func run(cmd *cobra.Command, _ []string) error {
 		ExtraBinds:      cfg.ExtraBinds,
 		NetworkMode:     cfg.NetworkMode,
 		Entrypoint:      cfg.Entrypoint,
+		Platform:        cfg.Platform,
 	}
 
 	if err := ctr.Run(ctx, runCfg); err != nil {

--- a/internal/container/api.go
+++ b/internal/container/api.go
@@ -16,6 +16,7 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/moby/go-archive"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"golang.org/x/term"
 )
 
@@ -164,6 +165,17 @@ func (a *apiClient) Run(ctx context.Context, cfg RunConfig) error {
 		ctrCfg.Entrypoint = []string{cfg.Entrypoint}
 	}
 
+	// ---- Platform (optional) -------------------------------------------
+	var platform *specs.Platform
+	if cfg.Platform != "" {
+		parts := strings.SplitN(cfg.Platform, "/", 2)
+		p := &specs.Platform{OS: parts[0]}
+		if len(parts) == 2 {
+			p.Architecture = parts[1]
+		}
+		platform = p
+	}
+
 	// ---- Create (no AutoRemove — we clean up ourselves) -----------------
 	createResp, err := a.cli.ContainerCreate(
 		ctx,
@@ -172,7 +184,7 @@ func (a *apiClient) Run(ctx context.Context, cfg RunConfig) error {
 			NetworkMode: container.NetworkMode(networkMode),
 			Binds:       binds,
 		},
-		nil, nil, "",
+		nil, platform, "",
 	)
 	if err != nil {
 		return fmt.Errorf("creating container: %w", err)

--- a/internal/container/client.go
+++ b/internal/container/client.go
@@ -18,6 +18,7 @@ type RunConfig struct {
 	ExtraBinds      []string // additional volume mounts in "host:container[:opts]" format
 	NetworkMode     string   // network mode ("host", "bridge", "none", …); empty defaults to "host"
 	Entrypoint      string   // override container entrypoint; empty = use image default
+	Platform        string   // OCI platform string e.g. "linux/amd64", "linux/arm64"; empty = daemon default
 }
 
 // Client is the interface both the Docker-SDK backend and the exec fallback

--- a/internal/container/exec.go
+++ b/internal/container/exec.go
@@ -96,6 +96,9 @@ func (e *execClient) Run(ctx context.Context, cfg RunConfig) error {
 		// '=value' is appended.
 		"-e", "GH_TOKEN",
 	}
+	if cfg.Platform != "" {
+		args = append(args, "--platform="+cfg.Platform)
+	}
 
 	if cfg.Workdir != "" {
 		absWorkdir, err := filepath.Abs(cfg.Workdir)


### PR DESCRIPTION
## Summary

- Adds `--platform` flag (e.g. `linux/amd64`, `linux/arm64`) to override the OCI platform used when running the container
- Wired through both the Docker SDK backend (`ContainerCreate` platform param) and the exec fallback (`docker run --platform`)
- Useful as a manual escape hatch; the arm64 fix (qjoly/kpil#12) makes it unnecessary for the normal case

## Test plan

- [ ] `go vet ./...` passes
- [ ] `go run main.go --platform linux/amd64 --image ghcr.io/qjoly/kpil:edge` forces amd64 image variant