### PR TITLE
feat: add Claude Code and OpenCode as selectable agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Binaries
 /copilot-kubectl-enforced
 /dist/
+/kpil
 
 # Go
 *.exe

--- a/Dockerfile
+++ b/Dockerfile
@@ -151,6 +151,17 @@ RUN echo "  Installing Claude Code (${CLAUDE_CODE_VERSION})…" \
     && claude --version
 
 # ---------------------------------------------------------------------------
+# OpenCode — sst/opencode terminal coding agent, installed globally via npm.
+# Selected at runtime with `kpil --agent opencode`. Provider auth is
+# performed inside the container with `opencode auth login` and persisted
+# on the host through the bind-mounts wired up by kpil.
+# ---------------------------------------------------------------------------
+ARG OPENCODE_VERSION=latest
+RUN echo "  Installing OpenCode (${OPENCODE_VERSION})…" \
+    && npm install -g "opencode-ai@${OPENCODE_VERSION}" \
+    && opencode --version
+
+# ---------------------------------------------------------------------------
 # Entrypoint — safety-net download of the Copilot CLI if absent, then
 # launches the requested agent (gh copilot or claude code).
 # ---------------------------------------------------------------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -141,8 +141,18 @@ RUN ARCH="$(dpkg --print-architecture)" \
     && echo "  Installed to /usr/local/bin/copilot"
 
 # ---------------------------------------------------------------------------
+# Claude Code — Anthropic's official coding agent CLI, installed globally via
+# npm.  Picked up at runtime when `kpil --agent claude` is used.  Pinned to a
+# specific version so rebuilds are reproducible.
+# ---------------------------------------------------------------------------
+ARG CLAUDE_CODE_VERSION=latest
+RUN echo "  Installing Claude Code (${CLAUDE_CODE_VERSION})…" \
+    && npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
+    && claude --version
+
+# ---------------------------------------------------------------------------
 # Entrypoint — safety-net download of the Copilot CLI if absent, then
-# launches gh copilot (interactive chat agent).
+# launches the requested agent (gh copilot or claude code).
 # ---------------------------------------------------------------------------
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # kpil (Kubernetes + Copilot)
 
-A CLI tool that provisions a scoped, read-only Kubernetes ServiceAccount (secrets excluded), generates a short-lived kubeconfig, and drops you directly into the **GitHub Copilot CLI** inside an isolated container — then cleans everything up when you exit.
+A CLI tool that provisions a scoped, read-only Kubernetes ServiceAccount (secrets excluded), generates a short-lived kubeconfig, and drops you directly into an AI coding agent — **GitHub Copilot CLI** or **Anthropic Claude Code** — inside an isolated container, then cleans everything up when you exit.
 
 ![demo](demo.gif)
 
@@ -49,7 +49,8 @@ This means the role works automatically with CRDs and custom API groups without 
 | Go 1.21+ | For building from source |
 | `docker` or `podman` | Auto-detected; `docker` preferred |
 | A kubeconfig with **cluster-admin** | Used only to provision RBAC |
-| `GH_TOKEN` env var | Fine-grained PAT with `copilot_requests: write` — see [docs/github-pat.md](docs/github-pat.md) |
+| `GH_TOKEN` env var | Required for `--agent copilot` (default). Fine-grained PAT with `copilot_requests: write` — see [docs/github-pat.md](docs/github-pat.md) |
+| `ANTHROPIC_API_KEY` env var | Required for `--agent claude`. Create one at [console.anthropic.com](https://console.anthropic.com/) |
 | A GitHub Copilot subscription | Required to use the Copilot CLI |
 | `cosign` (optional) | Required for image signature verification — see [docs/cosign.md](docs/cosign.md). Use `--insecure-image` to skip. |
 
@@ -95,21 +96,31 @@ cd kpil
 go build -o kpil .
 ```
 
-### 2. Export your GitHub token
+### 2. Export your AI agent credentials
 
-Create a fine-grained PAT scoped **only** to Copilot (see [docs/github-pat.md](docs/github-pat.md)):
+For **GitHub Copilot** (default), create a fine-grained PAT scoped only to Copilot (see [docs/github-pat.md](docs/github-pat.md)):
 
 ```sh
 export GH_TOKEN=github_pat_xxxxxxxxxxxx
 ```
 
+For **Anthropic Claude Code**, create an API key at [console.anthropic.com](https://console.anthropic.com/) and export it:
+
+```sh
+export ANTHROPIC_API_KEY=sk-ant-xxxxxxxxxxxx
+```
+
 ### 3. Run
 
 ```sh
+# GitHub Copilot (default)
 kpil
+
+# Claude Code
+kpil --agent claude
 ```
 
-The tool connects to the cluster in your current `KUBECONFIG`, provisions the RBAC resources, generates a restricted kubeconfig, and opens the Copilot CLI. When you exit, everything is deleted automatically.
+The tool connects to the cluster in your current `KUBECONFIG`, provisions the RBAC resources, generates a restricted kubeconfig, and opens the selected agent. When you exit, everything is deleted automatically.
 
 ---
 
@@ -119,6 +130,7 @@ The tool connects to the cluster in your current `KUBECONFIG`, provisions the RB
 kpil [flags]
 
 Flags:
+      --agent string     AI agent to launch: "copilot" or "claude" (default "copilot")
       --build            Build the image from the local Dockerfile instead of pulling
       --image string     Container image to run
                          (default "ghcr.io/qjoly/kpil:latest")
@@ -137,6 +149,9 @@ Flags:
 ### Examples
 
 ```sh
+# Launch Claude Code instead of GitHub Copilot
+ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY kpil --agent claude
+
 # Use a specific kubeconfig and namespace
 kpil --kubeconfig ~/.kube/staging --namespace platform
 
@@ -174,6 +189,8 @@ The image contains:
 - `kubectl` (latest stable at build time)
 - `gh` CLI (latest stable at build time)
 - `gh copilot` extension (pre-installed at build time — no token needed at build)
+- GitHub Copilot standalone CLI (`copilot` binary)
+- Anthropic Claude Code CLI (`claude`, installed via npm)
 
 The image requires **no token at build time**. `GH_TOKEN` is only needed at runtime and is forwarded automatically from your shell environment.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # kpil (Kubernetes + Copilot)
 
-A CLI tool that provisions a scoped, read-only Kubernetes ServiceAccount (secrets excluded), generates a short-lived kubeconfig, and drops you directly into an AI coding agent — **GitHub Copilot CLI** or **Anthropic Claude Code** — inside an isolated container, then cleans everything up when you exit.
+A CLI tool that provisions a scoped, read-only Kubernetes ServiceAccount (secrets excluded), generates a short-lived kubeconfig, and drops you directly into an AI coding agent — **GitHub Copilot CLI**, **Anthropic Claude Code**, or **OpenCode** — inside an isolated container, then cleans everything up when you exit.
 
 ![demo](demo.gif)
 
@@ -51,6 +51,7 @@ This means the role works automatically with CRDs and custom API groups without 
 | A kubeconfig with **cluster-admin** | Used only to provision RBAC |
 | `GH_TOKEN` env var | Required for `--agent copilot` (default). Fine-grained PAT with `copilot_requests: write` — see [docs/github-pat.md](docs/github-pat.md) |
 | A Claude Pro/Max subscription | Required for `--agent claude`. Sign in once via `/login` inside the agent on first run; the session is persisted under `~/.kpil/claude` on the host. `ANTHROPIC_API_KEY` is also honoured if you already have one. |
+| A provider account for OpenCode | Required for `--agent opencode`. Run `opencode auth login` on first run to pair a provider (Anthropic, OpenAI, …); the session is persisted under `~/.kpil/opencode` on the host. `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` are forwarded if set. |
 | A GitHub Copilot subscription | Required to use the Copilot CLI |
 | `cosign` (optional) | Required for image signature verification — see [docs/cosign.md](docs/cosign.md). Use `--insecure-image` to skip. |
 
@@ -117,6 +118,8 @@ If you happen to have an API key instead, it is also honoured:
 export ANTHROPIC_API_KEY=sk-ant-xxxxxxxxxxxx
 ```
 
+For **OpenCode**, run `opencode auth login` inside the agent on first run to authenticate with your preferred provider; the session is persisted in `~/.kpil/opencode` on the host. `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` are forwarded into the container if set.
+
 ### 3. Run
 
 ```sh
@@ -125,6 +128,9 @@ kpil
 
 # Claude Code
 kpil --agent claude
+
+# OpenCode
+kpil --agent opencode
 ```
 
 The tool connects to the cluster in your current `KUBECONFIG`, provisions the RBAC resources, generates a restricted kubeconfig, and opens the selected agent. When you exit, everything is deleted automatically.
@@ -137,10 +143,12 @@ The tool connects to the cluster in your current `KUBECONFIG`, provisions the RB
 kpil [flags]
 
 Flags:
-      --agent string         AI agent to launch: "copilot" or "claude" (default "copilot")
-      --claude-config string Host directory mounted at /root/.claude to persist the
-                             Claude Code subscription session (default: $HOME/.kpil/claude)
-      --build                Build the image from the local Dockerfile instead of pulling
+      --agent string           AI agent: "copilot", "claude", or "opencode" (default "copilot")
+      --claude-config string   Host directory mounted at /root/.claude to persist the
+                               Claude Code subscription session (default: $HOME/.kpil/claude)
+      --opencode-config string Host directory backing OpenCode's data + config dirs in
+                               the container (default: $HOME/.kpil/opencode)
+      --build                  Build the image from the local Dockerfile instead of pulling
       --image string     Container image to run
                          (default "ghcr.io/qjoly/kpil:latest")
       --insecure-image   Skip cosign signature verification (unsigned or local images)
@@ -160,6 +168,9 @@ Flags:
 ```sh
 # Launch Claude Code instead of GitHub Copilot (subscription auth — run /login on first launch)
 kpil --agent claude
+
+# Launch OpenCode (run `opencode auth login` on first launch to pair a provider)
+kpil --agent opencode
 
 # Use a specific kubeconfig and namespace
 kpil --kubeconfig ~/.kube/staging --namespace platform
@@ -200,6 +211,7 @@ The image contains:
 - `gh copilot` extension (pre-installed at build time — no token needed at build)
 - GitHub Copilot standalone CLI (`copilot` binary)
 - Anthropic Claude Code CLI (`claude`, installed via npm)
+- OpenCode CLI (`opencode`, installed via npm)
 
 The image requires **no token at build time**. `GH_TOKEN` is only needed at runtime and is forwarded automatically from your shell environment.
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ This means the role works automatically with CRDs and custom API groups without 
 | `docker` or `podman` | Auto-detected; `docker` preferred |
 | A kubeconfig with **cluster-admin** | Used only to provision RBAC |
 | `GH_TOKEN` env var | Required for `--agent copilot` (default). Fine-grained PAT with `copilot_requests: write` — see [docs/github-pat.md](docs/github-pat.md) |
-| `ANTHROPIC_API_KEY` env var | Required for `--agent claude`. Create one at [console.anthropic.com](https://console.anthropic.com/) |
+| A Claude Pro/Max subscription | Required for `--agent claude`. Sign in once via `/login` inside the agent on first run; the session is persisted under `~/.kpil/claude` on the host. `ANTHROPIC_API_KEY` is also honoured if you already have one. |
 | A GitHub Copilot subscription | Required to use the Copilot CLI |
 | `cosign` (optional) | Required for image signature verification — see [docs/cosign.md](docs/cosign.md). Use `--insecure-image` to skip. |
 
@@ -104,7 +104,14 @@ For **GitHub Copilot** (default), create a fine-grained PAT scoped only to Copil
 export GH_TOKEN=github_pat_xxxxxxxxxxxx
 ```
 
-For **Anthropic Claude Code**, create an API key at [console.anthropic.com](https://console.anthropic.com/) and export it:
+For **Anthropic Claude Code** with a **Claude Pro/Max subscription**, you don't need to set anything up-front. On first run, type `/login` inside the agent to start the OAuth flow; the resulting session is stored in `~/.kpil/claude` on the host and reused on subsequent runs.
+
+```sh
+# First run only — completes the /login flow once and persists the session
+kpil --agent claude
+```
+
+If you happen to have an API key instead, it is also honoured:
 
 ```sh
 export ANTHROPIC_API_KEY=sk-ant-xxxxxxxxxxxx
@@ -130,8 +137,10 @@ The tool connects to the cluster in your current `KUBECONFIG`, provisions the RB
 kpil [flags]
 
 Flags:
-      --agent string     AI agent to launch: "copilot" or "claude" (default "copilot")
-      --build            Build the image from the local Dockerfile instead of pulling
+      --agent string         AI agent to launch: "copilot" or "claude" (default "copilot")
+      --claude-config string Host directory mounted at /root/.claude to persist the
+                             Claude Code subscription session (default: $HOME/.kpil/claude)
+      --build                Build the image from the local Dockerfile instead of pulling
       --image string     Container image to run
                          (default "ghcr.io/qjoly/kpil:latest")
       --insecure-image   Skip cosign signature verification (unsigned or local images)
@@ -149,8 +158,8 @@ Flags:
 ### Examples
 
 ```sh
-# Launch Claude Code instead of GitHub Copilot
-ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY kpil --agent claude
+# Launch Claude Code instead of GitHub Copilot (subscription auth — run /login on first launch)
+kpil --agent claude
 
 # Use a specific kubeconfig and namespace
 kpil --kubeconfig ~/.kube/staging --namespace platform

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,6 +35,13 @@ type Config struct {
 	ExtraBinds  []string // additional volume mounts in "host:container[:opts]" format
 	Entrypoint  string   // override container entrypoint
 	Platform    string   // OCI platform string e.g. "linux/amd64", "linux/arm64"
+	Agent       string   // which AI agent to launch in the container: "copilot" or "claude"
+}
+
+// supportedAgents lists the agent identifiers accepted by --agent.
+var supportedAgents = map[string]struct{}{
+	"copilot": {},
+	"claude":  {},
 }
 
 var cfg Config
@@ -102,6 +109,9 @@ Requires --build. Example: --skill lobbi-docs/claude/kubernetes`)
 		"Prompt for runtime parameters (image, network mode, volume mounts, entrypoint)\n"+
 			"before launching the container.  Non-interactive behaviour is preserved when\n"+
 			"this flag is not set.")
+	rootCmd.Flags().StringVar(&cfg.Agent, "agent", "copilot",
+		"AI coding agent to launch inside the container: \"copilot\" (GitHub Copilot CLI,\n"+
+			"requires GH_TOKEN) or \"claude\" (Anthropic Claude Code, requires ANTHROPIC_API_KEY)")
 	rootCmd.Flags().StringVar(&cfg.Platform, "platform", "",
 		"OCI platform to run (e.g. linux/amd64, linux/arm64). Defaults to the daemon's native platform.\n"+
 			"Use linux/amd64 on Apple Silicon when the image has no arm64 variant.")
@@ -111,12 +121,27 @@ func run(cmd *cobra.Command, _ []string) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// ---- validate GH_TOKEN --------------------------------------------
-	if os.Getenv("GH_TOKEN") == "" {
-		return fmt.Errorf("GH_TOKEN is not set\n"+
-			"  A GitHub personal access token with the 'copilot' scope is required.\n"+
-			"  See docs/github-pat.md for instructions, then re-run with:\n"+
-			"    GH_TOKEN=<your-token> %s", os.Args[0])
+	// ---- validate --agent ---------------------------------------------
+	if _, ok := supportedAgents[cfg.Agent]; !ok {
+		return fmt.Errorf("unsupported --agent %q: expected \"copilot\" or \"claude\"", cfg.Agent)
+	}
+
+	// ---- validate agent credentials -----------------------------------
+	switch cfg.Agent {
+	case "copilot":
+		if os.Getenv("GH_TOKEN") == "" {
+			return fmt.Errorf("GH_TOKEN is not set\n"+
+				"  A GitHub personal access token with the 'copilot' scope is required for --agent copilot.\n"+
+				"  See docs/github-pat.md for instructions, then re-run with:\n"+
+				"    GH_TOKEN=<your-token> %s", os.Args[0])
+		}
+	case "claude":
+		if os.Getenv("ANTHROPIC_API_KEY") == "" {
+			return fmt.Errorf("ANTHROPIC_API_KEY is not set\n"+
+				"  An Anthropic API key is required for --agent claude.\n"+
+				"  Create one at https://console.anthropic.com/ and re-run with:\n"+
+				"    ANTHROPIC_API_KEY=<your-key> %s --agent claude", os.Args[0])
+		}
 	}
 
 	// ---- validate flag combinations ------------------------------------
@@ -246,7 +271,11 @@ func run(cmd *cobra.Command, _ []string) error {
 	}
 
 	// ---- Run container -------------------------------------------------
-	fmt.Printf("Starting GitHub Copilot CLI (image: %s)…\n", cfg.Image)
+	agentLabel := "GitHub Copilot CLI"
+	if cfg.Agent == "claude" {
+		agentLabel = "Anthropic Claude Code"
+	}
+	fmt.Printf("Starting %s (image: %s)…\n", agentLabel, cfg.Image)
 	if cfg.Workdir != "" {
 		access := "read-write"
 		if cfg.WorkdirReadOnly {
@@ -265,6 +294,7 @@ func run(cmd *cobra.Command, _ []string) error {
 		NetworkMode:     cfg.NetworkMode,
 		Entrypoint:      cfg.Entrypoint,
 		Platform:        cfg.Platform,
+		Agent:           cfg.Agent,
 	}
 
 	if err := ctr.Run(ctx, runCfg); err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -42,12 +42,17 @@ type Config struct {
 	// `claude /login` on first run) persists across kpil invocations. Empty
 	// means "use the default derived from $HOME".
 	ClaudeConfigDir string
+	// OpenCodeConfigDir is a host directory whose data/ and config/ subdirs
+	// are mounted at ~/.local/share/opencode and ~/.config/opencode inside
+	// the container so OpenCode's auth state and configuration persist.
+	OpenCodeConfigDir string
 }
 
 // supportedAgents lists the agent identifiers accepted by --agent.
 var supportedAgents = map[string]struct{}{
-	"copilot": {},
-	"claude":  {},
+	"copilot":  {},
+	"claude":   {},
+	"opencode": {},
 }
 
 var cfg Config
@@ -116,14 +121,20 @@ Requires --build. Example: --skill lobbi-docs/claude/kubernetes`)
 			"before launching the container.  Non-interactive behaviour is preserved when\n"+
 			"this flag is not set.")
 	rootCmd.Flags().StringVar(&cfg.Agent, "agent", "copilot",
-		"AI coding agent to launch inside the container: \"copilot\" (GitHub Copilot CLI,\n"+
-			"requires GH_TOKEN) or \"claude\" (Anthropic Claude Code, signs in to a Claude\n"+
-			"Pro/Max subscription via `claude /login` on first run; ANTHROPIC_API_KEY is\n"+
-			"forwarded if set but not required)")
+		"AI coding agent to launch inside the container:\n"+
+			"  \"copilot\"  GitHub Copilot CLI (requires GH_TOKEN)\n"+
+			"  \"claude\"   Anthropic Claude Code (signs in via `claude /login`; ANTHROPIC_API_KEY\n"+
+			"             also accepted if set)\n"+
+			"  \"opencode\" sst/opencode CLI (signs in via `opencode auth login`; ANTHROPIC_API_KEY\n"+
+			"             and OPENAI_API_KEY are forwarded if set)")
 	rootCmd.Flags().StringVar(&cfg.ClaudeConfigDir, "claude-config", "",
 		"Host directory mounted at /root/.claude in the container to persist the\n"+
 			"Claude Code subscription session across runs (default: $HOME/.kpil/claude).\n"+
 			"Only used when --agent claude.")
+	rootCmd.Flags().StringVar(&cfg.OpenCodeConfigDir, "opencode-config", "",
+		"Host directory whose data/ and config/ subdirs back OpenCode's\n"+
+			"~/.local/share/opencode and ~/.config/opencode inside the container\n"+
+			"(default: $HOME/.kpil/opencode). Only used when --agent opencode.")
 	rootCmd.Flags().StringVar(&cfg.Platform, "platform", "",
 		"OCI platform to run (e.g. linux/amd64, linux/arm64). Defaults to the daemon's native platform.\n"+
 			"Use linux/amd64 on Apple Silicon when the image has no arm64 variant.")
@@ -167,6 +178,33 @@ func run(cmd *cobra.Command, _ []string) error {
 			return fmt.Errorf("resolving --claude-config path %s: %w", cfg.ClaudeConfigDir, err)
 		}
 		cfg.ExtraBinds = append(cfg.ExtraBinds, absClaudeDir+":/root/.claude")
+	case "opencode":
+		// OpenCode keeps auth credentials under XDG_DATA_HOME (data/) and
+		// runtime config under XDG_CONFIG_HOME (config/). We persist both as
+		// sibling subdirs of a single host directory so `opencode auth login`
+		// only has to run once.
+		if cfg.OpenCodeConfigDir == "" {
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return fmt.Errorf("cannot determine $HOME for default --opencode-config: %w", err)
+			}
+			cfg.OpenCodeConfigDir = filepath.Join(home, ".kpil", "opencode")
+		}
+		absOC, err := filepath.Abs(cfg.OpenCodeConfigDir)
+		if err != nil {
+			return fmt.Errorf("resolving --opencode-config path %s: %w", cfg.OpenCodeConfigDir, err)
+		}
+		dataDir := filepath.Join(absOC, "data")
+		configDir := filepath.Join(absOC, "config")
+		for _, d := range []string{dataDir, configDir} {
+			if err := os.MkdirAll(d, 0o700); err != nil {
+				return fmt.Errorf("creating opencode dir %s: %w", d, err)
+			}
+		}
+		cfg.ExtraBinds = append(cfg.ExtraBinds,
+			dataDir+":/root/.local/share/opencode",
+			configDir+":/root/.config/opencode",
+		)
 	}
 
 	// ---- validate flag combinations ------------------------------------
@@ -297,8 +335,11 @@ func run(cmd *cobra.Command, _ []string) error {
 
 	// ---- Run container -------------------------------------------------
 	agentLabel := "GitHub Copilot CLI"
-	if cfg.Agent == "claude" {
+	switch cfg.Agent {
+	case "claude":
 		agentLabel = "Anthropic Claude Code"
+	case "opencode":
+		agentLabel = "OpenCode"
 	}
 	fmt.Printf("Starting %s (image: %s)…\n", agentLabel, cfg.Image)
 	if cfg.Workdir != "" {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 	"time"
 
@@ -36,6 +37,11 @@ type Config struct {
 	Entrypoint  string   // override container entrypoint
 	Platform    string   // OCI platform string e.g. "linux/amd64", "linux/arm64"
 	Agent       string   // which AI agent to launch in the container: "copilot" or "claude"
+	// ClaudeConfigDir is a host directory mounted at /root/.claude inside the
+	// container so the user's Claude Code subscription login (created via
+	// `claude /login` on first run) persists across kpil invocations. Empty
+	// means "use the default derived from $HOME".
+	ClaudeConfigDir string
 }
 
 // supportedAgents lists the agent identifiers accepted by --agent.
@@ -111,7 +117,13 @@ Requires --build. Example: --skill lobbi-docs/claude/kubernetes`)
 			"this flag is not set.")
 	rootCmd.Flags().StringVar(&cfg.Agent, "agent", "copilot",
 		"AI coding agent to launch inside the container: \"copilot\" (GitHub Copilot CLI,\n"+
-			"requires GH_TOKEN) or \"claude\" (Anthropic Claude Code, requires ANTHROPIC_API_KEY)")
+			"requires GH_TOKEN) or \"claude\" (Anthropic Claude Code, signs in to a Claude\n"+
+			"Pro/Max subscription via `claude /login` on first run; ANTHROPIC_API_KEY is\n"+
+			"forwarded if set but not required)")
+	rootCmd.Flags().StringVar(&cfg.ClaudeConfigDir, "claude-config", "",
+		"Host directory mounted at /root/.claude in the container to persist the\n"+
+			"Claude Code subscription session across runs (default: $HOME/.kpil/claude).\n"+
+			"Only used when --agent claude.")
 	rootCmd.Flags().StringVar(&cfg.Platform, "platform", "",
 		"OCI platform to run (e.g. linux/amd64, linux/arm64). Defaults to the daemon's native platform.\n"+
 			"Use linux/amd64 on Apple Silicon when the image has no arm64 variant.")
@@ -136,12 +148,25 @@ func run(cmd *cobra.Command, _ []string) error {
 				"    GH_TOKEN=<your-token> %s", os.Args[0])
 		}
 	case "claude":
-		if os.Getenv("ANTHROPIC_API_KEY") == "" {
-			return fmt.Errorf("ANTHROPIC_API_KEY is not set\n"+
-				"  An Anthropic API key is required for --agent claude.\n"+
-				"  Create one at https://console.anthropic.com/ and re-run with:\n"+
-				"    ANTHROPIC_API_KEY=<your-key> %s --agent claude", os.Args[0])
+		// Claude Code authenticates via a Claude Pro/Max subscription using
+		// `claude /login` on first run; the resulting session is persisted on
+		// the host in the mounted --claude-config directory. ANTHROPIC_API_KEY
+		// is forwarded if the user happens to have one, but it is not required.
+		if cfg.ClaudeConfigDir == "" {
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return fmt.Errorf("cannot determine $HOME for default --claude-config: %w", err)
+			}
+			cfg.ClaudeConfigDir = filepath.Join(home, ".kpil", "claude")
 		}
+		if err := os.MkdirAll(cfg.ClaudeConfigDir, 0o700); err != nil {
+			return fmt.Errorf("creating --claude-config dir %s: %w", cfg.ClaudeConfigDir, err)
+		}
+		absClaudeDir, err := filepath.Abs(cfg.ClaudeConfigDir)
+		if err != nil {
+			return fmt.Errorf("resolving --claude-config path %s: %w", cfg.ClaudeConfigDir, err)
+		}
+		cfg.ExtraBinds = append(cfg.ExtraBinds, absClaudeDir+":/root/.claude")
 	}
 
 	// ---- validate flag combinations ------------------------------------

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,32 +1,63 @@
 #!/bin/bash
 set -e
 
-if [ -z "$GH_TOKEN" ]; then
-  echo "Error: GH_TOKEN is not set." >&2
-  echo "       Re-run with: docker run -e GH_TOKEN=<token> ..." >&2
-  exit 1
-fi
+# Default to GitHub Copilot for backward compatibility.
+AGENT="${AGENT:-copilot}"
 
-# Ensure the GitHub Copilot CLI binary is present.
-# If the image was built correctly it will already be at /usr/local/bin/copilot.
-# This block is only a safety net for ad-hoc runs against an unbuilt image.
-if [ ! -x /usr/local/bin/copilot ]; then
-  echo "GitHub Copilot CLI not found — downloading…" >&2
-  # Map uname -m to the arch suffix used by github/copilot-cli releases:
-  #   x86_64  → x64
-  #   aarch64 → arm64
-  case "$(uname -m)" in
-    x86_64)  CLI_ARCH="x64" ;;
-    aarch64) CLI_ARCH="arm64" ;;
-    *)       CLI_ARCH="x64" ;;
-  esac
-  curl -fsSL \
-    "https://github.com/github/copilot-cli/releases/download/v1.0.35/copilot-linux-${CLI_ARCH}.tar.gz" \
-    | tar -xz -C /usr/local/bin copilot \
-  && chmod +x /usr/local/bin/copilot \
-  || {
-    echo "Warning: could not download GitHub Copilot CLI — proceeding anyway." >&2
-  }
-fi
+case "$AGENT" in
+  copilot)
+    if [ -z "$GH_TOKEN" ]; then
+      echo "Error: GH_TOKEN is not set." >&2
+      echo "       Re-run with: docker run -e GH_TOKEN=<token> ..." >&2
+      exit 1
+    fi
 
-exec gh copilot
+    # Ensure the GitHub Copilot CLI binary is present.
+    # If the image was built correctly it will already be at /usr/local/bin/copilot.
+    # This block is only a safety net for ad-hoc runs against an unbuilt image.
+    if [ ! -x /usr/local/bin/copilot ]; then
+      echo "GitHub Copilot CLI not found — downloading…" >&2
+      # Map uname -m to the arch suffix used by github/copilot-cli releases:
+      #   x86_64  → x64
+      #   aarch64 → arm64
+      case "$(uname -m)" in
+        x86_64)  CLI_ARCH="x64" ;;
+        aarch64) CLI_ARCH="arm64" ;;
+        *)       CLI_ARCH="x64" ;;
+      esac
+      curl -fsSL \
+        "https://github.com/github/copilot-cli/releases/download/v1.0.35/copilot-linux-${CLI_ARCH}.tar.gz" \
+        | tar -xz -C /usr/local/bin copilot \
+      && chmod +x /usr/local/bin/copilot \
+      || {
+        echo "Warning: could not download GitHub Copilot CLI — proceeding anyway." >&2
+      }
+    fi
+
+    exec gh copilot
+    ;;
+
+  claude)
+    if [ -z "$ANTHROPIC_API_KEY" ]; then
+      echo "Error: ANTHROPIC_API_KEY is not set." >&2
+      echo "       Re-run with: kpil --agent claude (with ANTHROPIC_API_KEY exported)" >&2
+      exit 1
+    fi
+
+    if ! command -v claude >/dev/null 2>&1; then
+      echo "Error: claude binary not found in the image." >&2
+      echo "       Rebuild the image with --build to install Claude Code." >&2
+      exit 1
+    fi
+
+    # `claude` with no args starts an interactive session.
+    # --dangerously-skip-permissions keeps parity with the Copilot flow:
+    # the container is already an isolated, read-only-RBAC sandbox.
+    exec claude --dangerously-skip-permissions
+    ;;
+
+  *)
+    echo "Error: unknown AGENT=\"$AGENT\" (expected \"copilot\" or \"claude\")." >&2
+    exit 1
+    ;;
+esac

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,19 +38,29 @@ case "$AGENT" in
     ;;
 
   claude)
-    if [ -z "$ANTHROPIC_API_KEY" ]; then
-      echo "Error: ANTHROPIC_API_KEY is not set." >&2
-      echo "       Re-run with: kpil --agent claude (with ANTHROPIC_API_KEY exported)" >&2
-      exit 1
-    fi
-
     if ! command -v claude >/dev/null 2>&1; then
       echo "Error: claude binary not found in the image." >&2
       echo "       Rebuild the image with --build to install Claude Code." >&2
       exit 1
     fi
 
-    # `claude` with no args starts an interactive session.
+    # Authentication:
+    #   - If /root/.claude already contains a credentials file (mounted from
+    #     the host's --claude-config directory), claude reuses the existing
+    #     Pro/Max subscription session.
+    #   - Otherwise claude prompts the user to run `/login` and walks them
+    #     through the OAuth flow; the resulting credentials are written under
+    #     /root/.claude and persist on the host via the bind mount.
+    #   - ANTHROPIC_API_KEY is honoured by the claude binary natively if set.
+    if [ ! -f /root/.claude/.credentials.json ] && [ -z "$ANTHROPIC_API_KEY" ]; then
+      echo "" >&2
+      echo "No Claude Code session found in /root/.claude." >&2
+      echo "On first run, type  /login  inside Claude Code to sign in with your" >&2
+      echo "Claude Pro/Max subscription. The session is then persisted on the host" >&2
+      echo "and reused on subsequent kpil --agent claude invocations." >&2
+      echo "" >&2
+    fi
+
     # --dangerously-skip-permissions keeps parity with the Copilot flow:
     # the container is already an isolated, read-only-RBAC sandbox.
     exec claude --dangerously-skip-permissions

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -61,13 +61,30 @@ case "$AGENT" in
       echo "" >&2
     fi
 
+    # Claude Code splits its state between two locations:
+    #   - ~/.claude/                — credentials, history, hooks, …
+    #                                 (already persisted via the bind mount)
+    #   - ~/.claude.json            — runtime config; pairs the OAuth token
+    #                                 to a user identity. NOT inside ~/.claude,
+    #                                 so a plain bind mount of ~/.claude alone
+    #                                 forces a re-login on every run.
+    # We stash a copy of .claude.json INSIDE the persisted ~/.claude directory
+    # and shuttle it in on start / out on exit so the OAuth login survives
+    # container teardown.
+    PERSIST_CONFIG="/root/.claude/.claude.json"
+    LIVE_CONFIG="/root/.claude.json"
+    if [ -f "$PERSIST_CONFIG" ] && [ ! -f "$LIVE_CONFIG" ]; then
+      cp "$PERSIST_CONFIG" "$LIVE_CONFIG"
+    fi
+    trap 'cp -f "$LIVE_CONFIG" "$PERSIST_CONFIG" 2>/dev/null || true' EXIT INT TERM
+
     # The container is itself the sandbox (read-only RBAC, no host filesystem
     # outside the bind-mounts, isolated network namespace), so we set
     # IS_SANDBOX=1 to let claude's --dangerously-skip-permissions work even
     # though the in-container UID is root. Without this claude refuses to
     # start with "cannot be used with root/sudo privileges".
     export IS_SANDBOX=1
-    exec claude --dangerously-skip-permissions
+    claude --dangerously-skip-permissions
     ;;
 
   *)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -61,8 +61,12 @@ case "$AGENT" in
       echo "" >&2
     fi
 
-    # --dangerously-skip-permissions keeps parity with the Copilot flow:
-    # the container is already an isolated, read-only-RBAC sandbox.
+    # The container is itself the sandbox (read-only RBAC, no host filesystem
+    # outside the bind-mounts, isolated network namespace), so we set
+    # IS_SANDBOX=1 to let claude's --dangerously-skip-permissions work even
+    # though the in-container UID is root. Without this claude refuses to
+    # start with "cannot be used with root/sudo privileges".
+    export IS_SANDBOX=1
     exec claude --dangerously-skip-permissions
     ;;
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -87,8 +87,31 @@ case "$AGENT" in
     claude --dangerously-skip-permissions
     ;;
 
+  opencode)
+    if ! command -v opencode >/dev/null 2>&1; then
+      echo "Error: opencode binary not found in the image." >&2
+      echo "       Rebuild the image with --build to install OpenCode." >&2
+      exit 1
+    fi
+
+    # OpenCode authenticates with its providers via `opencode auth login`.
+    # Credentials are written under ~/.local/share/opencode/auth.json, which
+    # is bind-mounted from the host, so the login persists across runs.
+    if [ ! -f /root/.local/share/opencode/auth.json ] \
+       && [ -z "$ANTHROPIC_API_KEY" ] && [ -z "$OPENAI_API_KEY" ]; then
+      echo "" >&2
+      echo "No OpenCode session found in /root/.local/share/opencode." >&2
+      echo "On first run, run  opencode auth login  inside the container to sign in" >&2
+      echo "with your provider (Anthropic, OpenAI, …). The session is then persisted" >&2
+      echo "on the host and reused on subsequent kpil --agent opencode invocations." >&2
+      echo "" >&2
+    fi
+
+    exec opencode
+    ;;
+
   *)
-    echo "Error: unknown AGENT=\"$AGENT\" (expected \"copilot\" or \"claude\")." >&2
+    echo "Error: unknown AGENT=\"$AGENT\" (expected \"copilot\", \"claude\", or \"opencode\")." >&2
     exit 1
     ;;
 esac

--- a/internal/container/api.go
+++ b/internal/container/api.go
@@ -133,6 +133,11 @@ func (a *apiClient) Run(ctx context.Context, cfg RunConfig) error {
 	}
 
 	ghToken := os.Getenv("GH_TOKEN")
+	anthropicKey := os.Getenv("ANTHROPIC_API_KEY")
+	agent := cfg.Agent
+	if agent == "" {
+		agent = "copilot"
+	}
 
 	binds := []string{absKubeconfig + ":/root/.kube/config:ro"}
 	if cfg.Workdir != "" {
@@ -161,7 +166,7 @@ func (a *apiClient) Run(ctx context.Context, cfg RunConfig) error {
 		AttachStdin:  true,
 		AttachStdout: true,
 		AttachStderr: true,
-		Env:          []string{"GH_TOKEN=" + ghToken},
+		Env:          []string{"GH_TOKEN=" + ghToken, "ANTHROPIC_API_KEY=" + anthropicKey, "AGENT=" + agent},
 	}
 	if cfg.Entrypoint != "" {
 		ctrCfg.Entrypoint = []string{cfg.Entrypoint}

--- a/internal/container/api.go
+++ b/internal/container/api.go
@@ -134,6 +134,7 @@ func (a *apiClient) Run(ctx context.Context, cfg RunConfig) error {
 
 	ghToken := os.Getenv("GH_TOKEN")
 	anthropicKey := os.Getenv("ANTHROPIC_API_KEY")
+	openaiKey := os.Getenv("OPENAI_API_KEY")
 	agent := cfg.Agent
 	if agent == "" {
 		agent = "copilot"
@@ -166,7 +167,12 @@ func (a *apiClient) Run(ctx context.Context, cfg RunConfig) error {
 		AttachStdin:  true,
 		AttachStdout: true,
 		AttachStderr: true,
-		Env:          []string{"GH_TOKEN=" + ghToken, "ANTHROPIC_API_KEY=" + anthropicKey, "AGENT=" + agent},
+		Env: []string{
+			"GH_TOKEN=" + ghToken,
+			"ANTHROPIC_API_KEY=" + anthropicKey,
+			"OPENAI_API_KEY=" + openaiKey,
+			"AGENT=" + agent,
+		},
 	}
 	if cfg.Entrypoint != "" {
 		ctrCfg.Entrypoint = []string{cfg.Entrypoint}

--- a/internal/container/client.go
+++ b/internal/container/client.go
@@ -19,6 +19,7 @@ type RunConfig struct {
 	NetworkMode     string   // network mode ("host", "bridge", "none", …); empty defaults to "host"
 	Entrypoint      string   // override container entrypoint; empty = use image default
 	Platform        string   // OCI platform string e.g. "linux/amd64", "linux/arm64"; empty = daemon default
+	Agent           string   // "copilot" or "claude" — exported as AGENT env var so entrypoint.sh can route
 }
 
 // Client is the interface both the Docker-SDK backend and the exec fallback

--- a/internal/container/exec.go
+++ b/internal/container/exec.go
@@ -91,11 +91,17 @@ func (e *execClient) Run(ctx context.Context, cfg RunConfig) error {
 		"-it",
 		"--network=" + networkMode,
 		"-v", fmt.Sprintf("%s:/root/.kube/config:ro", absKubeconfig),
-		// Forward GH_TOKEN without reading its value in Go — both Docker and
-		// Podman resolve the value from the calling process env when no
+		// Forward credentials without reading their values in Go — both Docker
+		// and Podman resolve the value from the calling process env when no
 		// '=value' is appended.
 		"-e", "GH_TOKEN",
+		"-e", "ANTHROPIC_API_KEY",
 	}
+	agent := cfg.Agent
+	if agent == "" {
+		agent = "copilot"
+	}
+	args = append(args, "-e", "AGENT="+agent)
 	if cfg.Platform != "" {
 		args = append(args, "--platform="+cfg.Platform)
 	}

--- a/internal/container/exec.go
+++ b/internal/container/exec.go
@@ -96,6 +96,7 @@ func (e *execClient) Run(ctx context.Context, cfg RunConfig) error {
 		// '=value' is appended.
 		"-e", "GH_TOKEN",
 		"-e", "ANTHROPIC_API_KEY",
+		"-e", "OPENAI_API_KEY",
 	}
 	agent := cfg.Agent
 	if agent == "" {


### PR DESCRIPTION
## Summary
- New `--agent` flag picks the in-container AI coding agent: `copilot` (default, GitHub Copilot CLI), `claude` (Anthropic Claude Code), or `opencode` (sst/opencode). The RBAC + scoped kubeconfig sandbox is unchanged — only the launched agent differs.
- **Claude Code** authenticates against a Claude Pro/Max subscription via `claude /login` on first run. Session is persisted via `--claude-config` (default `$HOME/.kpil/claude`). `IS_SANDBOX=1` is set so `--dangerously-skip-permissions` works as the in-container root user, and `/root/.claude.json` is shuttled in/out of the persisted dir on each run so the login survives container teardown. `ANTHROPIC_API_KEY` still honored if set.
- **OpenCode** authenticates via `opencode auth login` on first run. Session is persisted via `--opencode-config` (default `$HOME/.kpil/opencode`, with `data/` → `~/.local/share/opencode` and `config/` → `~/.config/opencode`). `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` are forwarded if set.
- Dockerfile installs `@anthropic-ai/claude-code` and `opencode-ai` globally via npm. Entrypoint routes on `AGENT`.

## Test plan
- [x] `go vet ./...` and `go build` clean.
- [x] Image builds; `claude --version` → `2.1.168`, `opencode --version` → `1.16.2`.
- [x] Entrypoint routing: unknown `AGENT` rejected; `copilot` still requires `GH_TOKEN`; `claude` and `opencode` surface a first-run `/login` hint when no session is present.
- [x] End-to-end on `admin@luccakube-local-qjoly` with `--agent claude`: RBAC + RO kubeconfig OK, `AGENT=claude` forwarded, `~/.kpil/claude` mounted writable at `/root/.claude`, `auth can-i list pods = yes` / `list secrets = no`, RBAC cleanup on exit. Real `/login` flow confirmed by user.
- [x] End-to-end on `admin@luccakube-local-qjoly` with `--agent opencode`: RBAC + RO kubeconfig OK, `AGENT=opencode` forwarded, `~/.kpil/opencode/data` and `~/.kpil/opencode/config` mounted writable at the right paths, `auth can-i list pods = yes` / `list secrets = no`, RBAC cleanup on exit.
- [ ] Real `opencode auth login` against a provider (not exercised in CI — path is identical to claude `/login` validated above).