### PR TITLE
docs: add Claude Code and OpenCode pages to the Hugo site

### DIFF
--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -11,13 +11,13 @@ layout: hextra-home
 
 <div class="hx-mt-6 hx-mb-6">
 {{< hextra/hero-headline >}}
-  Kubernetes + GitHub Copilot,&nbsp;<br class="sm:hx-block hx-hidden" />safely isolated
+  Kubernetes + your AI agent,&nbsp;<br class="sm:hx-block hx-hidden" />safely isolated
 {{< /hextra/hero-headline >}}
 </div>
 
 <div class="hx-mb-12">
 {{< hextra/hero-subtitle >}}
-  Spin up a read-only kubeconfig and run GitHub Copilot CLI&nbsp;<br class="sm:hx-block hx-hidden" />in an ephemeral container — zero credentials left behind.
+  Spin up a read-only kubeconfig and run GitHub Copilot CLI, Claude Code, or OpenCode&nbsp;<br class="sm:hx-block hx-hidden" />in an ephemeral container — zero credentials left behind.
 {{< /hextra/hero-subtitle >}}
 </div>
 
@@ -56,5 +56,10 @@ layout: hextra-home
     title="Interactive setup"
     subtitle="Use -i to interactively configure image, network mode, volumes, and entrypoint."
     icon="adjustments"
+  >}}
+  {{< hextra/feature-card
+    title="Pick your agent"
+    subtitle="Switch between GitHub Copilot, Anthropic Claude Code, and sst/opencode with a single --agent flag."
+    icon="switch-horizontal"
   >}}
 {{< /hextra/feature-grid >}}

--- a/site/content/docs/_index.md
+++ b/site/content/docs/_index.md
@@ -5,4 +5,10 @@ weight: 1
 
 Welcome to the **kpil** documentation.
 
-kpil provisions a scoped, read-only Kubernetes ServiceAccount (secrets excluded), generates a short-lived kubeconfig, and drops you into the GitHub Copilot CLI inside an isolated container — then cleans everything up on exit.
+kpil provisions a scoped, read-only Kubernetes ServiceAccount (secrets excluded), generates a short-lived kubeconfig, and drops you into your AI coding agent of choice — **GitHub Copilot CLI**, **Anthropic Claude Code**, or **OpenCode** — inside an isolated container, then cleans everything up on exit.
+
+Pick an agent with `--agent` and follow the per-agent setup page:
+
+- [GitHub Token](github-token) — for `--agent copilot` (default)
+- [Claude Code](claude) — for `--agent claude`
+- [OpenCode](opencode) — for `--agent opencode`

--- a/site/content/docs/claude.md
+++ b/site/content/docs/claude.md
@@ -1,0 +1,60 @@
+---
+title: Claude Code
+weight: 4
+---
+
+Run [Anthropic Claude Code](https://www.anthropic.com/claude-code) inside the kpil sandbox with `--agent claude`. Authentication uses your Claude Pro/Max subscription via the standard OAuth flow.
+
+```sh
+kpil --agent claude
+```
+
+## First-run setup
+
+On the first run, no credentials file exists yet, so kpil prints a hint:
+
+```
+No Claude Code session found in /root/.claude.
+On first run, type  /login  inside Claude Code to sign in with your
+Claude Pro/Max subscription. The session is then persisted on the host
+and reused on subsequent kpil --agent claude invocations.
+```
+
+Inside the agent prompt, type `/login`. Claude Code prints a URL — open it in your browser, complete the OAuth dance, and paste the resulting code back into the agent. The credentials are written under `/root/.claude/.credentials.json`, which is bind-mounted from the host so the login survives container teardown.
+
+## Where the session is stored
+
+By default, kpil persists Claude Code's state under:
+
+```
+$HOME/.kpil/claude/
+```
+
+The directory is created automatically with mode `0700` and mounted at `/root/.claude` inside the container. Override the location with `--claude-config`:
+
+```sh
+kpil --agent claude --claude-config /path/to/store
+```
+
+The runtime config file (`/root/.claude.json`, which pairs the OAuth token to a user identity) is shuttled in and out of the persisted dir on each run by the entrypoint, so a single `/login` is enough.
+
+## API key alternative
+
+If you have an Anthropic API key, export it before launching and Claude Code will use it instead of the subscription flow:
+
+```sh
+export ANTHROPIC_API_KEY=sk-ant-xxxxxxxxxxxx
+kpil --agent claude
+```
+
+## Running as root inside the container
+
+The container runs as `root`, and Claude Code's `--dangerously-skip-permissions` refuses to start under root by default. The container is itself the sandbox (read-only RBAC, no host filesystem outside the bind mounts, isolated network namespace), so kpil sets `IS_SANDBOX=1` in the entrypoint — the documented escape hatch for this exact use case.
+
+## Reset
+
+To force a fresh login, remove the persisted state on the host:
+
+```sh
+rm -rf ~/.kpil/claude
+```

--- a/site/content/docs/flags.md
+++ b/site/content/docs/flags.md
@@ -9,6 +9,9 @@ kpil [flags]
 
 | Flag | Default | Description |
 |---|---|---|
+| `--agent` | `copilot` | AI agent to launch: `copilot`, `claude`, or `opencode` |
+| `--claude-config` | `$HOME/.kpil/claude` | Host directory mounted at `/root/.claude` to persist the Claude Code subscription session. Only used with `--agent claude`. |
+| `--opencode-config` | `$HOME/.kpil/opencode` | Host directory whose `data/` and `config/` subdirs back OpenCode's `~/.local/share/opencode` and `~/.config/opencode`. Only used with `--agent opencode`. |
 | `--image` | `ghcr.io/qjoly/kpil:latest` | Container image to run |
 | `--kubeconfig` | `$KUBECONFIG` or `~/.kube/config` | Admin kubeconfig path |
 | `--namespace` | `default` | Namespace for the ServiceAccount |
@@ -29,6 +32,12 @@ kpil [flags]
 ## Examples
 
 ```sh
+# Launch Claude Code instead of Copilot
+kpil --agent claude
+
+# Launch OpenCode
+kpil --agent opencode
+
 # Use a specific kubeconfig and namespace
 kpil --kubeconfig ~/.kube/staging --namespace platform
 

--- a/site/content/docs/getting-started.md
+++ b/site/content/docs/getting-started.md
@@ -9,9 +9,14 @@ weight: 1
 |---|---|
 | `docker` or `podman` | Auto-detected; Docker preferred |
 | Admin kubeconfig | Needs cluster-admin to provision RBAC |
-| `GH_TOKEN` env var | Fine-grained PAT with `copilot_requests: write` |
-| GitHub Copilot subscription | Required to use the Copilot CLI |
 | `cosign` (optional) | For image signature verification — use `--insecure-image` to skip |
+| Agent credentials | Depends on `--agent` — see the per-agent rows below |
+
+| `--agent` value | What it runs | Auth needed |
+|---|---|---|
+| `copilot` *(default)* | [GitHub Copilot CLI](github-token) | `GH_TOKEN` (fine-grained PAT with `copilot_requests: write`) + an active Copilot subscription |
+| `claude` | [Anthropic Claude Code](claude) | Claude Pro/Max subscription via `claude /login` on first run, or `ANTHROPIC_API_KEY` |
+| `opencode` | [sst/opencode](opencode) | Provider auth via `opencode auth login` on first run, or `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` |
 
 ## Installation
 
@@ -42,26 +47,38 @@ go build -o kpil .
 
 ## Usage
 
-### 1. Set your GitHub token
+### 1. Pick an agent and provide credentials
 
-Create a fine-grained PAT with `copilot_requests: write` (see [GitHub Token](github-token)):
+**Copilot** (default) — set a fine-grained PAT with `copilot_requests: write` (details on the [GitHub Token](github-token) page):
 
 ```sh
 export GH_TOKEN=github_pat_xxxxxxxxxxxx
+kpil                          # --agent copilot is implicit
 ```
 
-### 2. Run
+**Claude Code** — no env var needed up front. On first run, type `/login` inside the agent to authenticate your Claude Pro/Max subscription. The OAuth session is persisted in `~/.kpil/claude` and reused on every subsequent run. See [Claude Code](claude).
 
 ```sh
-kpil
+kpil --agent claude
 ```
+
+**OpenCode** — on first run, type `opencode auth login` inside the agent to pair a provider (Anthropic, OpenAI, …). The session is persisted in `~/.kpil/opencode` and reused next time. See [OpenCode](opencode).
+
+```sh
+kpil --agent opencode
+```
+
+If you already have an `ANTHROPIC_API_KEY` or `OPENAI_API_KEY` exported, kpil forwards them into the container automatically — handy for non-subscription flows.
+
+### 2. What happens
 
 kpil will:
 1. Connect to your current `KUBECONFIG` cluster
 2. Create a `ServiceAccount`, `ClusterRole` (no secrets), and `ClusterRoleBinding`
 3. Issue a 24h token and write `./ro-kubeconfig`
-4. Pull and start the container with the read-only kubeconfig mounted
-5. On exit, delete all RBAC resources and the kubeconfig
+4. Pull (or build) and start the container with the read-only kubeconfig mounted
+5. Launch the requested agent
+6. On exit, delete all RBAC resources and the kubeconfig
 
 ## How it works
 
@@ -72,13 +89,13 @@ sequenceDiagram
     participant C as Kubernetes cluster
     participant D as Container
 
-    U->>K: kpil
+    U->>K: kpil --agent <copilot|claude|opencode>
     K->>C: Create ServiceAccount, ClusterRole, ClusterRoleBinding
     K->>C: Request 24h token
     C-->>K: Token issued
     K->>K: Write ./ro-kubeconfig (mode 0600)
-    K->>D: docker run -v ro-kubeconfig -e GH_TOKEN
-    D-->>U: gh copilot (interactive session)
+    K->>D: docker run -v ro-kubeconfig -e AGENT -e GH_TOKEN / ANTHROPIC_API_KEY / OPENAI_API_KEY
+    D-->>U: selected agent (interactive session)
     U->>D: exit
     K->>C: Delete ClusterRoleBinding, ClusterRole, ServiceAccount
     K->>K: Delete ./ro-kubeconfig

--- a/site/content/docs/image.md
+++ b/site/content/docs/image.md
@@ -1,6 +1,6 @@
 ---
 title: Container Image
-weight: 4
+weight: 6
 ---
 
 Images are published to [ghcr.io/qjoly/kpil](https://github.com/qjoly/kpil/pkgs/container/kpil).
@@ -21,8 +21,12 @@ The image is built for `linux/amd64` and `linux/arm64`.
 ## Contents
 
 - `kubectl` (latest stable at build time)
-- `gh` CLI (latest stable at build time)
+- `gh` CLI + `gh copilot` extension (latest stable at build time)
 - `copilot` binary (from [github/copilot-cli](https://github.com/github/copilot-cli))
+- `claude` binary — [Anthropic Claude Code](https://www.anthropic.com/claude-code), installed via `@anthropic-ai/claude-code`
+- `opencode` binary — [sst/opencode](https://github.com/sst/opencode), installed via `opencode-ai`
+
+The entrypoint dispatches to the right agent at runtime based on the `AGENT` environment variable set by kpil (mirroring `--agent`).
 
 ## Signature verification
 

--- a/site/content/docs/opencode.md
+++ b/site/content/docs/opencode.md
@@ -1,0 +1,64 @@
+---
+title: OpenCode
+weight: 5
+---
+
+Run [sst/opencode](https://github.com/sst/opencode) inside the kpil sandbox with `--agent opencode`. OpenCode is provider-agnostic — pair it with Anthropic, OpenAI, or any other supported provider.
+
+```sh
+kpil --agent opencode
+```
+
+## First-run setup
+
+On the first run, no auth file exists, so kpil prints a hint:
+
+```
+No OpenCode session found in /root/.local/share/opencode.
+On first run, run  opencode auth login  inside the container to sign in
+with your provider (Anthropic, OpenAI, …). The session is then persisted
+on the host and reused on subsequent kpil --agent opencode invocations.
+```
+
+Inside the agent prompt, run:
+
+```
+opencode auth login
+```
+
+Pick your provider, follow the prompts, and the credentials are written to `/root/.local/share/opencode/auth.json` — bind-mounted from the host so the login survives container teardown.
+
+## Where the session is stored
+
+By default, kpil persists OpenCode's state under:
+
+```
+$HOME/.kpil/opencode/
+├── data/      → /root/.local/share/opencode   (auth, history, model state)
+└── config/    → /root/.config/opencode        (user configuration)
+```
+
+Both subdirs are created automatically with mode `0700`. Override the parent directory with `--opencode-config`:
+
+```sh
+kpil --agent opencode --opencode-config /path/to/store
+```
+
+## API key alternative
+
+If you already have provider credentials in env vars, OpenCode picks them up directly. kpil forwards both:
+
+```sh
+export ANTHROPIC_API_KEY=sk-ant-xxxxxxxxxxxx
+# or
+export OPENAI_API_KEY=sk-xxxxxxxxxxxx
+kpil --agent opencode
+```
+
+## Reset
+
+To force a fresh login, remove the persisted state on the host:
+
+```sh
+rm -rf ~/.kpil/opencode
+```

--- a/site/hugo.yaml
+++ b/site/hugo.yaml
@@ -18,7 +18,7 @@ ignoreLogs:
   - warning-deprecated
 
 params:
-  description: Provision a scoped read-only Kubernetes kubeconfig and launch GitHub Copilot CLI in an isolated container.
+  description: Provision a scoped read-only Kubernetes kubeconfig and launch GitHub Copilot CLI, Anthropic Claude Code, or OpenCode in an isolated container.
   navbar:
     displayTitle: true
     displayLogo: true


### PR DESCRIPTION
## Summary
Follow-up to #27 (now merged): teach the user-facing docs about the new `--agent claude` and `--agent opencode` flows. The README was updated in #27; this PR brings the Hugo site to parity.

Changes:
- Homepage tagline and a new "Pick your agent" feature card.
- `docs/_index.md` lists the three per-agent setup pages.
- `getting-started.md` requirements table reorganized; usage walks through credentials for each agent.
- `flags.md` documents `--agent`, `--claude-config`, `--opencode-config` and adds examples per agent.
- `image.md` lists the `claude` + `opencode` binaries baked into the image and notes the AGENT-based dispatch.
- New pages `docs/claude.md` and `docs/opencode.md` covering first-run setup, where the session is stored, API-key alternatives, and reset.

## Test plan
- [x] No new shortcodes introduced; existing Hextra patterns reused.
- [ ] Visual review of the deployed site once the Pages workflow runs.