### PR TITLE
feat(cli): check for newer image on startup and prompt to pull

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,10 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          # Generate an SPDX SBOM and attach it via OCI Referrers so kpil's
+          # startup staleness check can read the baked-in claude/opencode
+          # versions without pulling the image.
+          sbom: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -69,6 +69,9 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          # Re-generate the SBOM on every nightly so syft picks up the new
+          # claude/opencode versions resolved from npm "latest" at build time.
+          sbom: true
           # The whole point of the nightly is to pull fresh upstream layers,
           # so disable the layer cache and force a base-image re-pull.
           no-cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,9 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          # Attach an SPDX SBOM so kpil's startup staleness check can read
+          # the baked-in claude/opencode versions without pulling the image.
+          sbom: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -127,18 +127,25 @@ RUN --mount=type=bind,source=.,target=/build-ctx \
 # TARGETARCH is intentionally avoided: BuildKit's native cross-compilation
 # mode sets it to the *build host* arch rather than the target arch.
 # ---------------------------------------------------------------------------
+ARG COPILOT_CLI_VERSION=1.0.35
 RUN ARCH="$(dpkg --print-architecture)" \
     && case "${ARCH}" in \
          amd64) CLI_ARCH="x64" ;; \
          arm64) CLI_ARCH="arm64" ;; \
          *)     CLI_ARCH="x64" ;; \
        esac \
-    && echo "  Downloading GitHub Copilot CLI (linux-${CLI_ARCH})…" \
+    && echo "  Downloading GitHub Copilot CLI v${COPILOT_CLI_VERSION} (linux-${CLI_ARCH})…" \
     && curl -fsSL \
-        "https://github.com/github/copilot-cli/releases/download/v1.0.35/copilot-linux-${CLI_ARCH}.tar.gz" \
+        "https://github.com/github/copilot-cli/releases/download/v${COPILOT_CLI_VERSION}/copilot-linux-${CLI_ARCH}.tar.gz" \
         | tar -xz -C /usr/local/bin copilot \
     && chmod +x /usr/local/bin/copilot \
     && echo "  Installed to /usr/local/bin/copilot"
+
+# Copilot CLI is a raw binary, not an npm package — it does not appear in the
+# image's auto-generated SBOM. Expose its pinned version as an OCI label so
+# `kpil`'s startup staleness check can read it from the registry config blob
+# without pulling any layers.
+LABEL org.kpil.copilot.version="${COPILOT_CLI_VERSION}"
 
 # ---------------------------------------------------------------------------
 # Claude Code — Anthropic's official coding agent CLI, installed globally via

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,6 +10,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -413,7 +414,15 @@ func maybePullIfStale(ctx context.Context, ctr container.Client, img string) (bo
 	if err != nil {
 		return false, fmt.Errorf("reading remote digest: %w", err)
 	}
-	if remote == "" || remote == local {
+	if remote == "" {
+		return false, nil
+	}
+	// Podman stores the per-platform manifest digest in RepoDigests while the
+	// registry returns the index digest for a tag — strict equality would
+	// false-positive on every multi-arch tag. Treat the local image as
+	// up-to-date when its digest is the current arch's child of the remote
+	// index (or vice versa).
+	if container.SameImage(ctx, img, local, remote) {
 		return false, nil
 	}
 
@@ -487,26 +496,41 @@ func readLineCtx(ctx context.Context, r io.Reader) (string, error) {
 // copilot) and prints a table when at least one side reports a version.
 // Failures are silent: the digest mismatch is already informative on its own.
 func printAgentVersionDiff(ctx context.Context, img, localDigest, remoteDigest string) {
-	vCtx, cancel := context.WithTimeout(ctx, 8*time.Second)
+	// 20 s budget split across two registry lookups (each potentially fetching
+	// a multi-MB SBOM blob) plus an optional local-container probe.
+	vCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
 	defer cancel()
 
-	localVersions := container.FetchAgentVersions(vCtx, img, localDigest)
-	remoteVersions := container.FetchAgentVersions(vCtx, img, remoteDigest)
+	// Local registry lookup, remote registry lookup, and the local-container
+	// fallback can all run concurrently — none depend on each other's
+	// results — so we never pay the cost of their sum on the wall clock.
+	var (
+		localVersions, remoteVersions, fallbackVersions map[string]string
+		wg                                              sync.WaitGroup
+	)
+	wg.Add(3)
+	go func() {
+		defer wg.Done()
+		localVersions = container.FetchAgentVersions(vCtx, img, localDigest)
+	}()
+	go func() {
+		defer wg.Done()
+		remoteVersions = container.FetchAgentVersions(vCtx, img, remoteDigest)
+	}()
+	go func() {
+		defer wg.Done()
+		fallbackVersions = container.LocalAgentVersions(vCtx, img)
+	}()
+	wg.Wait()
+	if localVersions == nil {
+		localVersions = map[string]string{}
+	}
 
-	// Older locally-stored images may predate kpil's SBOM-enabled CI, so the
-	// registry lookup returns no SBOM for them. Fall back to running the
-	// image briefly and parsing each agent's --version output so the user
-	// sees a useful "before" column even on pre-SBOM images.
-	if localVersions["claude"] == "" || localVersions["opencode"] == "" || localVersions["copilot"] == "" {
-		if extra := container.LocalAgentVersions(vCtx, img); extra != nil {
-			if localVersions == nil {
-				localVersions = map[string]string{}
-			}
-			for k, v := range extra {
-				if localVersions[k] == "" {
-					localVersions[k] = v
-				}
-			}
+	// Merge the local-container probe results, but only as fallback values:
+	// the registry-side SBOM/label is canonical when present.
+	for k, v := range fallbackVersions {
+		if localVersions[k] == "" {
+			localVersions[k] = v
 		}
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,17 +1,22 @@
 package cmd
 
 import (
+	"bufio"
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
 	"github.com/qjoly/kpil/internal/container"
 	"github.com/qjoly/kpil/internal/k8s"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 // Config holds all the CLI configuration.
@@ -227,12 +232,15 @@ func run(cmd *cobra.Command, _ []string) error {
 	}
 
 	// ---- signal handling -----------------------------------------------
+	// First signal triggers graceful cancellation; the second restores the
+	// default handler so an impatient user can always force-exit with ^C^C.
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
 		<-sigCh
-		fmt.Fprintln(os.Stderr, "\nSignal received — stopping container…")
+		fmt.Fprintln(os.Stderr, "\nSignal received — cleaning up…")
 		cancel()
+		signal.Reset(syscall.SIGINT, syscall.SIGTERM)
 	}()
 
 	// ---- Kubernetes client ---------------------------------------------
@@ -307,6 +315,15 @@ func run(cmd *cobra.Command, _ []string) error {
 		}
 		if exists {
 			fmt.Printf("Image %s found locally.\n", cfg.Image)
+			pulled, err := maybePullIfStale(ctx, ctr, cfg.Image)
+			switch {
+			case errors.Is(err, context.Canceled):
+				return nil
+			case err != nil:
+				fmt.Fprintf(os.Stderr, "Warning: could not check for a newer image: %v\n", err)
+			case pulled:
+				fmt.Println("Image updated to the latest registry version.")
+			}
 		} else {
 			fmt.Printf("Image %s not found locally — attempting to pull…\n", cfg.Image)
 			if pullErr := ctr.Pull(ctx, cfg.Image); pullErr != nil {
@@ -368,6 +385,133 @@ func run(cmd *cobra.Command, _ []string) error {
 	}
 
 	return nil
+}
+
+// maybePullIfStale compares the locally stored image digest against the
+// remote registry digest. When they differ, the user is prompted (Y/n) and the
+// image is pulled on confirmation.
+//
+// Returns (true, nil) when a new version was pulled, (false, nil) when the
+// image is current, the user declined, the runtime backend doesn't support
+// the lookup, or stdin isn't a TTY (no way to prompt). Registry/inspect
+// errors propagate so the caller can surface a warning.
+func maybePullIfStale(ctx context.Context, ctr container.Client, img string) (bool, error) {
+	local, err := ctr.LocalDigest(ctx, img)
+	if err != nil {
+		return false, fmt.Errorf("reading local digest: %w", err)
+	}
+	if local == "" {
+		// Image was built locally or has no registry-bound digest — there's
+		// nothing meaningful to compare against, skip silently.
+		return false, nil
+	}
+	remote, err := ctr.RemoteDigest(ctx, img)
+	if err != nil {
+		return false, fmt.Errorf("reading remote digest: %w", err)
+	}
+	if remote == "" || remote == local {
+		return false, nil
+	}
+
+	fmt.Printf("A newer version of %s is available in the registry.\n", img)
+	fmt.Printf("  local digest:  %s\n", local)
+	fmt.Printf("  remote digest: %s\n", remote)
+	printAgentVersionDiff(ctx, img, local, remote)
+
+	if !term.IsTerminal(int(os.Stdin.Fd())) {
+		fmt.Println("  Stdin is not a TTY — keeping the local image. Re-run with --pull to update.")
+		return false, nil
+	}
+
+	fmt.Print("Pull the latest version now? [Y/n]: ")
+	line, err := readLineCtx(ctx, os.Stdin)
+	if err != nil {
+		if ctx.Err() != nil {
+			// Caller (signal handler) already printed a cleanup message.
+			return false, ctx.Err()
+		}
+		return false, fmt.Errorf("reading confirmation: %w", err)
+	}
+	answer := strings.ToLower(strings.TrimSpace(line))
+	if answer != "" && answer != "y" && answer != "yes" {
+		fmt.Println("Keeping the local image.")
+		return false, nil
+	}
+
+	if err := ctr.Pull(ctx, img); err != nil {
+		return false, fmt.Errorf("pulling latest image: %w", err)
+	}
+	return true, nil
+}
+
+// readLineCtx reads a single line from r, returning early with ctx.Err() if
+// ctx is cancelled while we're still blocked on input. The reader goroutine
+// is leaked (still pinned on the syscall), but the process is on its way out
+// when ctx fires, so the leak is bounded.
+func readLineCtx(ctx context.Context, r io.Reader) (string, error) {
+	type result struct {
+		line string
+		err  error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		line, err := bufio.NewReader(r).ReadString('\n')
+		ch <- result{line, err}
+	}()
+	select {
+	case <-ctx.Done():
+		fmt.Println()
+		return "", ctx.Err()
+	case res := <-ch:
+		return res.line, res.err
+	}
+}
+
+// printAgentVersionDiff fetches the per-agent version metadata baked into
+// both the local and remote image (SBOM for claude/opencode, OCI label for
+// copilot) and prints a table when at least one side reports a version.
+// Failures are silent: the digest mismatch is already informative on its own.
+func printAgentVersionDiff(ctx context.Context, img, localDigest, remoteDigest string) {
+	vCtx, cancel := context.WithTimeout(ctx, 8*time.Second)
+	defer cancel()
+
+	localVersions := container.FetchAgentVersions(vCtx, img, localDigest)
+	remoteVersions := container.FetchAgentVersions(vCtx, img, remoteDigest)
+	if len(localVersions) == 0 && len(remoteVersions) == 0 {
+		return
+	}
+
+	agents := []string{"claude", "opencode", "copilot"}
+	any := false
+	for _, a := range agents {
+		if localVersions[a] != "" || remoteVersions[a] != "" {
+			any = true
+			break
+		}
+	}
+	if !any {
+		return
+	}
+
+	fmt.Println("  baked-in agent versions:")
+	for _, a := range agents {
+		lv, rv := localVersions[a], remoteVersions[a]
+		if lv == "" && rv == "" {
+			continue
+		}
+		marker := "  "
+		if lv != rv && lv != "" && rv != "" {
+			marker = "→ "
+		}
+		fmt.Printf("    %s%-8s  %s  →  %s\n", marker, a, fallback(lv, "?"), fallback(rv, "?"))
+	}
+}
+
+func fallback(s, def string) string {
+	if s == "" {
+		return def
+	}
+	return s
 }
 
 // cleanupRBAC deletes RBAC resources based on what was actually provisioned.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -393,9 +393,13 @@ func run(cmd *cobra.Command, _ []string) error {
 //
 // Returns (true, nil) when a new version was pulled, (false, nil) when the
 // image is current, the user declined, the runtime backend doesn't support
-// the lookup, or stdin isn't a TTY (no way to prompt). Registry/inspect
-// errors propagate so the caller can surface a warning.
+// the lookup, the KPIL_SKIP_UPDATE_CHECK env var is set, or stdin isn't a
+// TTY (no way to prompt). Registry/inspect errors propagate so the caller
+// can surface a warning.
 func maybePullIfStale(ctx context.Context, ctr container.Client, img string) (bool, error) {
+	if skipUpdateCheck() {
+		return false, nil
+	}
 	local, err := ctr.LocalDigest(ctx, img)
 	if err != nil {
 		return false, fmt.Errorf("reading local digest: %w", err)
@@ -442,6 +446,17 @@ func maybePullIfStale(ctx context.Context, ctr container.Client, img string) (bo
 		return false, fmt.Errorf("pulling latest image: %w", err)
 	}
 	return true, nil
+}
+
+// skipUpdateCheck reports whether the startup staleness check should be
+// suppressed. Set KPIL_SKIP_UPDATE_CHECK to any non-empty value other than
+// "0", "false", or "no" (case-insensitive) to opt out.
+func skipUpdateCheck() bool {
+	v := strings.ToLower(strings.TrimSpace(os.Getenv("KPIL_SKIP_UPDATE_CHECK")))
+	if v == "" {
+		return false
+	}
+	return v != "0" && v != "false" && v != "no"
 }
 
 // readLineCtx reads a single line from r, returning early with ctx.Err() if

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -492,6 +492,24 @@ func printAgentVersionDiff(ctx context.Context, img, localDigest, remoteDigest s
 
 	localVersions := container.FetchAgentVersions(vCtx, img, localDigest)
 	remoteVersions := container.FetchAgentVersions(vCtx, img, remoteDigest)
+
+	// Older locally-stored images may predate kpil's SBOM-enabled CI, so the
+	// registry lookup returns no SBOM for them. Fall back to running the
+	// image briefly and parsing each agent's --version output so the user
+	// sees a useful "before" column even on pre-SBOM images.
+	if localVersions["claude"] == "" || localVersions["opencode"] == "" || localVersions["copilot"] == "" {
+		if extra := container.LocalAgentVersions(vCtx, img); extra != nil {
+			if localVersions == nil {
+				localVersions = map[string]string{}
+			}
+			for k, v := range extra {
+				if localVersions[k] == "" {
+					localVersions[k] = v
+				}
+			}
+		}
+	}
+
 	if len(localVersions) == 0 && len(remoteVersions) == 0 {
 		return
 	}

--- a/internal/container/api.go
+++ b/internal/container/api.go
@@ -58,6 +58,35 @@ func (a *apiClient) ImageExists(ctx context.Context, img string) (bool, error) {
 	return false, fmt.Errorf("inspecting image %s: %w", img, err)
 }
 
+// LocalDigest returns the manifest digest of the locally stored image, as
+// recorded in its RepoDigests. Returns "" if the image was built locally and
+// has no associated registry digest.
+func (a *apiClient) LocalDigest(ctx context.Context, img string) (string, error) {
+	info, _, err := a.cli.ImageInspectWithRaw(ctx, img)
+	if err != nil {
+		if client.IsErrNotFound(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("inspecting image %s: %w", img, err)
+	}
+	return digestForImage(img, info.RepoDigests), nil
+}
+
+// RemoteDigest contacts the registry and returns the current manifest digest
+// for img without pulling any layers. Falls back to a direct HTTP query when
+// the daemon's DistributionInspect endpoint fails (e.g. older daemons or
+// rootless podman setups that block egress from the daemon).
+func (a *apiClient) RemoteDigest(ctx context.Context, img string) (string, error) {
+	d, err := a.cli.DistributionInspect(ctx, img, "")
+	if err == nil {
+		return string(d.Descriptor.Digest), nil
+	}
+	if httpDigest, httpErr := fetchRegistryDigest(ctx, img); httpErr == nil && httpDigest != "" {
+		return httpDigest, nil
+	}
+	return "", fmt.Errorf("inspecting remote image %s: %w", img, err)
+}
+
 // Pull pulls the image from a remote registry, streaming progress to stdout.
 func (a *apiClient) Pull(ctx context.Context, img string) error {
 	fmt.Printf("  Pulling image %s…\n", img)

--- a/internal/container/api_windows.go
+++ b/internal/container/api_windows.go
@@ -22,6 +22,14 @@ func (a *apiClient) ImageExists(_ context.Context, _ string) (bool, error) {
 	return false, fmt.Errorf("not supported on Windows")
 }
 
+func (a *apiClient) LocalDigest(_ context.Context, _ string) (string, error) {
+	return "", fmt.Errorf("not supported on Windows")
+}
+
+func (a *apiClient) RemoteDigest(_ context.Context, _ string) (string, error) {
+	return "", fmt.Errorf("not supported on Windows")
+}
+
 func (a *apiClient) Pull(_ context.Context, _ string) error {
 	return fmt.Errorf("not supported on Windows")
 }

--- a/internal/container/client.go
+++ b/internal/container/client.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
+	"strings"
 )
 
 // RunConfig holds what the container runner needs to start the container.
@@ -31,6 +32,15 @@ type Client interface {
 
 	// ImageExists reports whether the image is present in the local store.
 	ImageExists(ctx context.Context, image string) (bool, error)
+
+	// LocalDigest returns the content digest (e.g. "sha256:…") of the locally
+	// stored image. Returns an empty string if the image has no associated
+	// digest (e.g. it was built locally and never pushed/pulled).
+	LocalDigest(ctx context.Context, image string) (string, error)
+
+	// RemoteDigest fetches the manifest digest of the image from its remote
+	// registry without pulling any layers.
+	RemoteDigest(ctx context.Context, image string) (string, error)
 
 	// Pull pulls the image from a remote registry.
 	Pull(ctx context.Context, image string) error
@@ -146,6 +156,32 @@ func canDial(path string) bool {
 	}
 	conn.Close()
 	return true
+}
+
+// digestForImage extracts the manifest digest matching img from a list of
+// repo digests of the form "repo@sha256:…". It first looks for the entry whose
+// repo prefix matches img (so we ignore digests for unrelated tags pulled into
+// the same image ID); if none matches, the first available digest is returned.
+// Returns "" when the list is empty (image built locally, never pushed/pulled).
+func digestForImage(img string, repoDigests []string) string {
+	repoPrefix := img
+	if i := strings.Index(repoPrefix, "@"); i >= 0 {
+		repoPrefix = repoPrefix[:i]
+	}
+	if i := strings.LastIndex(repoPrefix, ":"); i >= 0 && i > strings.LastIndex(repoPrefix, "/") {
+		repoPrefix = repoPrefix[:i]
+	}
+	for _, rd := range repoDigests {
+		if strings.HasPrefix(rd, repoPrefix+"@") {
+			return strings.SplitN(rd, "@", 2)[1]
+		}
+	}
+	if len(repoDigests) > 0 {
+		if parts := strings.SplitN(repoDigests[0], "@", 2); len(parts) == 2 {
+			return parts[1]
+		}
+	}
+	return ""
 }
 
 // detectRuntimeCLI validates / auto-detects the CLI binary name.

--- a/internal/container/exec.go
+++ b/internal/container/exec.go
@@ -1,7 +1,9 @@
 package container
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -33,6 +35,34 @@ func (e *execClient) ImageExists(_ context.Context, img string) (bool, error) {
 		return false, nil
 	}
 	return false, fmt.Errorf("inspecting image %s: %w", img, err)
+}
+
+// LocalDigest returns the manifest digest recorded in RepoDigests for the
+// locally stored image. Returns "" if the image was built locally and has no
+// associated registry digest.
+func (e *execClient) LocalDigest(_ context.Context, img string) (string, error) {
+	cmd := exec.Command(e.runtime, "image", "inspect", "--format", "{{json .RepoDigests}}", img)
+	out, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() != 0 {
+			return "", nil
+		}
+		return "", fmt.Errorf("inspecting image %s: %w", img, err)
+	}
+	var repoDigests []string
+	if err := json.Unmarshal(bytes.TrimSpace(out), &repoDigests); err != nil {
+		return "", fmt.Errorf("parsing repo digests for %s: %w", img, err)
+	}
+	return digestForImage(img, repoDigests), nil
+}
+
+// RemoteDigest fetches the current manifest digest for img directly from its
+// registry over HTTP. The runtime CLIs do not reliably surface the top-level
+// index/list digest for multi-arch tags, whereas the Docker-Content-Digest
+// response header always does — and it matches what gets recorded in
+// RepoDigests after a pull.
+func (e *execClient) RemoteDigest(ctx context.Context, img string) (string, error) {
+	return fetchRegistryDigest(ctx, img)
 }
 
 // Pull pulls the image from a remote registry.

--- a/internal/container/local_versions.go
+++ b/internal/container/local_versions.go
@@ -1,0 +1,74 @@
+package container
+
+import (
+	"bufio"
+	"context"
+	"os/exec"
+	"regexp"
+	"strings"
+)
+
+// LocalAgentVersions extracts the baked-in agent versions of a locally
+// stored image by running it briefly with a no-op entrypoint and parsing the
+// `--version` output of each agent binary.
+//
+// This is the fallback for the on-startup version diff when the local image
+// has no SBOM attached (e.g. it was pulled before kpil's CI started
+// publishing SBOMs, or it was built with `--build`).
+//
+// Returns an empty map if no runtime CLI is available or the container
+// failed to start — silent failure is fine because the caller already has
+// the digest diff to show.
+func LocalAgentVersions(ctx context.Context, img string) map[string]string {
+	rt, err := detectRuntimeCLI("")
+	if err != nil {
+		return nil
+	}
+	// One probe per agent. The "|| true" suffix prevents a missing binary
+	// from short-circuiting the whole script.
+	script := strings.Join([]string{
+		`claude=$(claude --version 2>/dev/null || true)`,
+		`opencode=$(opencode --version 2>/dev/null || true)`,
+		`copilot=$(copilot --version 2>/dev/null | head -1 || true)`,
+		`echo "claude=$claude"`,
+		`echo "opencode=$opencode"`,
+		`echo "copilot=$copilot"`,
+	}, "; ")
+	cmd := exec.CommandContext(ctx, rt, "run", "--rm",
+		"--entrypoint", "sh",
+		"--network=none",
+		img, "-c", script)
+	out, err := cmd.Output()
+	if err != nil {
+		return nil
+	}
+	return parseAgentVersionLines(out)
+}
+
+// agentVersionPattern matches the first semver-like sequence (e.g. "2.1.173",
+// "v1.0.35", "0.10.5-rc.2") in a line of arbitrary surrounding text.
+var agentVersionPattern = regexp.MustCompile(`v?(\d+\.\d+\.\d+(?:[-+][\w.]+)?)`)
+
+func parseAgentVersionLines(out []byte) map[string]string {
+	versions := map[string]string{}
+	scanner := bufio.NewScanner(strings.NewReader(string(out)))
+	for scanner.Scan() {
+		line := scanner.Text()
+		eq := strings.IndexByte(line, '=')
+		if eq < 0 {
+			continue
+		}
+		agent := strings.TrimSpace(line[:eq])
+		raw := strings.TrimSpace(line[eq+1:])
+		if raw == "" {
+			continue
+		}
+		if m := agentVersionPattern.FindStringSubmatch(raw); m != nil {
+			versions[agent] = m[1]
+		}
+	}
+	if len(versions) == 0 {
+		return nil
+	}
+	return versions
+}

--- a/internal/container/registry.go
+++ b/internal/container/registry.go
@@ -1,0 +1,163 @@
+package container
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// acceptManifests lists every media type a v2 registry might serve for a tag.
+// Sent on every manifest request so the registry returns the index/list digest
+// rather than redirecting to a per-platform manifest.
+var acceptManifests = strings.Join([]string{
+	"application/vnd.oci.image.index.v1+json",
+	"application/vnd.docker.distribution.manifest.list.v2+json",
+	"application/vnd.oci.image.manifest.v1+json",
+	"application/vnd.docker.distribution.manifest.v2+json",
+}, ", ")
+
+// fetchRegistryDigest issues a HEAD on the registry's manifest endpoint and
+// returns the Docker-Content-Digest header value — i.e. the same digest that
+// `docker pull` records in RepoDigests. Handles anonymous bearer-token auth
+// for registries like ghcr.io and docker.io.
+//
+// Returns "" with no error when the registry omits the digest header (some
+// older or non-conformant registries do), so the caller can skip silently.
+func fetchRegistryDigest(ctx context.Context, img string) (string, error) {
+	registry, repo, ref := parseImageRef(img)
+	url := fmt.Sprintf("https://%s/v2/%s/manifests/%s", registry, repo, ref)
+
+	digest, err := manifestHead(ctx, url, "")
+	if err == nil {
+		return digest, nil
+	}
+
+	// 401 → try anonymous token, then retry once.
+	authErr, ok := err.(*authChallenge)
+	if !ok {
+		return "", err
+	}
+	token, err := fetchBearerToken(ctx, authErr.header, repo)
+	if err != nil {
+		return "", fmt.Errorf("registry auth failed: %w", err)
+	}
+	return manifestHead(ctx, url, token)
+}
+
+type authChallenge struct {
+	header string
+}
+
+func (e *authChallenge) Error() string { return "registry requires auth: " + e.header }
+
+func manifestHead(ctx context.Context, url, bearer string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, url, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", acceptManifests)
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return "", &authChallenge{header: resp.Header.Get("Www-Authenticate")}
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("registry returned %s for %s", resp.Status, url)
+	}
+	return resp.Header.Get("Docker-Content-Digest"), nil
+}
+
+// parseImageRef splits "registry/repo:tag" or "registry/repo@digest" into its
+// three components. Docker Hub short forms ("alpine", "library/alpine:3.18")
+// are normalized to registry-1.docker.io with the library/ prefix.
+func parseImageRef(img string) (registry, repo, ref string) {
+	if i := strings.Index(img, "@"); i >= 0 {
+		ref = img[i+1:]
+		img = img[:i]
+	}
+
+	tag := "latest"
+	if i := strings.LastIndex(img, ":"); i > strings.LastIndex(img, "/") {
+		tag = img[i+1:]
+		img = img[:i]
+	}
+	if ref == "" {
+		ref = tag
+	}
+
+	parts := strings.SplitN(img, "/", 2)
+	first := parts[0]
+	hasRegistry := len(parts) == 2 && (strings.ContainsAny(first, ".:") || first == "localhost")
+	if !hasRegistry {
+		registry = "registry-1.docker.io"
+		repo = img
+		if !strings.Contains(repo, "/") {
+			repo = "library/" + repo
+		}
+		return
+	}
+	return first, parts[1], ref
+}
+
+func fetchBearerToken(ctx context.Context, authHeader, repo string) (string, error) {
+	if !strings.HasPrefix(authHeader, "Bearer ") {
+		return "", fmt.Errorf("unsupported auth scheme: %q", authHeader)
+	}
+	params := map[string]string{}
+	for _, kv := range strings.Split(authHeader[len("Bearer "):], ",") {
+		kv = strings.TrimSpace(kv)
+		i := strings.Index(kv, "=")
+		if i < 0 {
+			continue
+		}
+		params[kv[:i]] = strings.Trim(kv[i+1:], `"`)
+	}
+	realm := params["realm"]
+	if realm == "" {
+		return "", fmt.Errorf("no realm in WWW-Authenticate")
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, realm, nil)
+	if err != nil {
+		return "", err
+	}
+	q := req.URL.Query()
+	if s := params["service"]; s != "" {
+		q.Set("service", s)
+	}
+	scope := params["scope"]
+	if scope == "" {
+		scope = "repository:" + repo + ":pull"
+	}
+	q.Set("scope", scope)
+	req.URL.RawQuery = q.Encode()
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("token endpoint returned %s", resp.Status)
+	}
+	var body struct {
+		Token       string `json:"token"`
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return "", err
+	}
+	if body.Token != "" {
+		return body.Token, nil
+	}
+	return body.AccessToken, nil
+}

--- a/internal/container/registry.go
+++ b/internal/container/registry.go
@@ -134,11 +134,10 @@ func fetchBearerToken(ctx context.Context, authHeader, repo string) (string, err
 	if s := params["service"]; s != "" {
 		q.Set("service", s)
 	}
-	scope := params["scope"]
-	if scope == "" {
-		scope = "repository:" + repo + ":pull"
-	}
-	q.Set("scope", scope)
+	// The scope param in the challenge is often a placeholder (GHCR returns
+	// "repository:user/image:pull"). Always pin it to the repo we actually
+	// want to read so the returned token authorizes our request.
+	q.Set("scope", "repository:"+repo+":pull")
 	req.URL.RawQuery = q.Encode()
 
 	resp, err := http.DefaultClient.Do(req)

--- a/internal/container/registry.go
+++ b/internal/container/registry.go
@@ -108,6 +108,55 @@ func parseImageRef(img string) (registry, repo, ref string) {
 	return first, parts[1], ref
 }
 
+// SameImage reports whether local and remote refer to the same OCI image
+// content even when one is an image index and the other is one of its
+// per-platform child manifests.
+//
+// This handles podman's habit of storing the platform-specific manifest
+// digest in RepoDigests (so LocalDigest returns e.g. the arm64 child) while
+// `manifest inspect` on a tag returns the parent index digest — making a
+// plain `local == remote` comparison miss a no-op pull.
+func SameImage(ctx context.Context, img, local, remote string) bool {
+	if local == remote || local == "" || remote == "" {
+		return local == remote
+	}
+	registry, repo, _ := parseImageRef(img)
+	token, _ := authForRepo(ctx, registry, repo)
+
+	if isChildOfIndex(ctx, registry, repo, remote, local, token) {
+		return true
+	}
+	return isChildOfIndex(ctx, registry, repo, local, remote, token)
+}
+
+// isChildOfIndex returns true when parent identifies an OCI image index whose
+// manifests array references child. Attestation-manifest descriptors are
+// skipped — only real image manifests count as platform children.
+func isChildOfIndex(ctx context.Context, registry, repo, parent, child, token string) bool {
+	body, mediaType, err := fetchManifest(ctx, registry, repo, parent, token)
+	if err != nil || !isIndexMediaType(mediaType) {
+		return false
+	}
+	var idx struct {
+		Manifests []struct {
+			Digest      string            `json:"digest"`
+			Annotations map[string]string `json:"annotations"`
+		} `json:"manifests"`
+	}
+	if err := json.Unmarshal(body, &idx); err != nil {
+		return false
+	}
+	for _, m := range idx.Manifests {
+		if m.Annotations["vnd.docker.reference.type"] != "" {
+			continue // skip attestation-manifests
+		}
+		if m.Digest == child {
+			return true
+		}
+	}
+	return false
+}
+
 func fetchBearerToken(ctx context.Context, authHeader, repo string) (string, error) {
 	if !strings.HasPrefix(authHeader, "Bearer ") {
 		return "", fmt.Errorf("unsupported auth scheme: %q", authHeader)

--- a/internal/container/sbom.go
+++ b/internal/container/sbom.go
@@ -152,19 +152,37 @@ func fetchConfigLabels(ctx context.Context, registry, repo, digest, token string
 }
 
 // fetchSBOMPackageVersions returns a map of npm-style package name → version
-// extracted from the SPDX SBOM that buildx attaches as an OCI referrer of
-// digest. Returns an empty (non-nil) map when no SBOM is attached.
+// extracted from the SPDX SBOM attached to the image at digest.
+//
+// Buildx with `sbom: true` does not push the SBOM via the OCI Referrers API
+// (which GHCR doesn't fully support — it 303-redirects). Instead, buildx
+// embeds an "attestation-manifest" inside the image index, one per platform,
+// referencing back to the platform image via the
+// `vnd.docker.reference.digest` annotation. Each attestation-manifest's
+// layers are in-toto statements; the SPDX SBOM lives in the layer whose
+// `in-toto.io/predicate-type` annotation is `https://spdx.dev/Document`,
+// with the SPDX document carried inline in the statement's `predicate`
+// field.
+//
+// We optimistically try the OCI Referrers API first (works on registries
+// that support it) and fall back to scanning the image index for the
+// attestation-manifest.
 func fetchSBOMPackageVersions(ctx context.Context, registry, repo, digest, token string) (map[string]string, error) {
-	descriptors, err := fetchReferrers(ctx, registry, repo, digest, token)
-	if err != nil {
-		return nil, err
+	if out := tryReferrerSBOM(ctx, registry, repo, digest, token); len(out) > 0 {
+		return out, nil
 	}
+	return fetchAttestationSBOM(ctx, registry, repo, digest, token)
+}
 
+// tryReferrerSBOM probes the OCI Referrers API. Returns nil silently when
+// the registry doesn't expose referrers or none are SBOMs.
+func tryReferrerSBOM(ctx context.Context, registry, repo, digest, token string) map[string]string {
+	descriptors, err := fetchReferrers(ctx, registry, repo, digest, token)
+	if err != nil || len(descriptors) == 0 {
+		return nil
+	}
 	out := map[string]string{}
 	for _, ref := range descriptors {
-		// Buildx attaches the SBOM as an OCI image manifest whose layers carry
-		// the SPDX JSON. The referrer's `artifactType` is set on the manifest
-		// itself; the SPDX blob is the first layer.
 		sbomManifest, _, err := fetchManifest(ctx, registry, repo, ref.Digest, token)
 		if err != nil {
 			continue
@@ -180,47 +198,99 @@ func fetchSBOMPackageVersions(ctx context.Context, registry, repo, digest, token
 			continue
 		}
 		if !isSBOMArtifactType(ref.ArtifactType) && !isSBOMArtifactType(mf.ArtifactType) {
-			// Could be a provenance attestation or some other referrer; skip.
 			continue
 		}
 		for _, layer := range mf.Layers {
 			if !isSPDXMediaType(layer.MediaType) {
 				continue
 			}
-			blob, err := fetchBlob(ctx, registry, repo, layer.Digest, token)
-			if err != nil {
-				continue
-			}
-			extractSPDXVersions(blob, out)
-		}
-	}
-
-	// For multi-arch images the top-level index may have no referrers — the
-	// SBOM is attached per platform. Fall back to the linux manifest.
-	if len(out) == 0 {
-		idxBody, mediaType, err := fetchManifest(ctx, registry, repo, digest, token)
-		if err == nil && isIndexMediaType(mediaType) {
-			var idx struct {
-				Manifests []struct {
-					Digest   string `json:"digest"`
-					Platform struct {
-						OS string `json:"os"`
-					} `json:"platform"`
-				} `json:"manifests"`
-			}
-			if err := json.Unmarshal(idxBody, &idx); err == nil {
-				for _, m := range idx.Manifests {
-					if m.Platform.OS != "linux" {
-						continue
-					}
-					if sub, err := fetchSBOMPackageVersions(ctx, registry, repo, m.Digest, token); err == nil && len(sub) > 0 {
-						return sub, nil
-					}
-				}
+			if blob, err := fetchBlob(ctx, registry, repo, layer.Digest, token); err == nil {
+				extractSPDXVersions(blob, out)
 			}
 		}
 	}
+	return out
+}
 
+// fetchAttestationSBOM extracts the SPDX SBOM that buildx embeds inside the
+// image index as an attestation-manifest (in-toto statement wrapping SPDX).
+func fetchAttestationSBOM(ctx context.Context, registry, repo, digest, token string) (map[string]string, error) {
+	indexBody, mediaType, err := fetchManifest(ctx, registry, repo, digest, token)
+	if err != nil {
+		return nil, err
+	}
+	if !isIndexMediaType(mediaType) {
+		// A single-arch image with no index: buildx attaches no SBOM here.
+		return nil, nil
+	}
+
+	var idx struct {
+		Manifests []struct {
+			Digest      string            `json:"digest"`
+			Annotations map[string]string `json:"annotations"`
+			Platform    struct {
+				OS string `json:"os"`
+			} `json:"platform"`
+		} `json:"manifests"`
+	}
+	if err := json.Unmarshal(indexBody, &idx); err != nil {
+		return nil, fmt.Errorf("parsing image index: %w", err)
+	}
+
+	var linuxImageDigest string
+	for _, m := range idx.Manifests {
+		if m.Platform.OS == "linux" && m.Annotations["vnd.docker.reference.type"] == "" {
+			linuxImageDigest = m.Digest
+			break
+		}
+	}
+	if linuxImageDigest == "" {
+		return nil, nil
+	}
+	var attestDigest string
+	for _, m := range idx.Manifests {
+		if m.Annotations["vnd.docker.reference.type"] == "attestation-manifest" &&
+			m.Annotations["vnd.docker.reference.digest"] == linuxImageDigest {
+			attestDigest = m.Digest
+			break
+		}
+	}
+	if attestDigest == "" {
+		return nil, nil
+	}
+
+	attestBody, _, err := fetchManifest(ctx, registry, repo, attestDigest, token)
+	if err != nil {
+		return nil, err
+	}
+	var attest struct {
+		Layers []struct {
+			MediaType   string            `json:"mediaType"`
+			Digest      string            `json:"digest"`
+			Annotations map[string]string `json:"annotations"`
+		} `json:"layers"`
+	}
+	if err := json.Unmarshal(attestBody, &attest); err != nil {
+		return nil, fmt.Errorf("parsing attestation manifest: %w", err)
+	}
+
+	out := map[string]string{}
+	for _, layer := range attest.Layers {
+		if layer.Annotations["in-toto.io/predicate-type"] != "https://spdx.dev/Document" {
+			continue
+		}
+		blob, err := fetchBlob(ctx, registry, repo, layer.Digest, token)
+		if err != nil {
+			continue
+		}
+		var stmt struct {
+			Predicate json.RawMessage `json:"predicate"`
+		}
+		if err := json.Unmarshal(blob, &stmt); err != nil {
+			continue
+		}
+		extractSPDXVersions(stmt.Predicate, out)
+	}
 	return out, nil
 }
 

--- a/internal/container/sbom.go
+++ b/internal/container/sbom.go
@@ -1,0 +1,348 @@
+package container
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// agentSBOMPackages maps the canonical agent identifier surfaced by kpil
+// (claude/opencode) to the npm package name that syft records in the SBOM.
+// Copilot CLI is excluded on purpose — it's a raw binary download that syft's
+// npm/dpkg catalogers do not see, so we surface its version through an OCI
+// LABEL on the image config instead.
+var agentSBOMPackages = map[string]string{
+	"claude":   "@anthropic-ai/claude-code",
+	"opencode": "opencode-ai",
+}
+
+// agentLabels maps agent identifiers to the OCI label keys kpil bakes into
+// the image. Currently only copilot uses this channel.
+var agentLabels = map[string]string{
+	"copilot": "org.kpil.copilot.version",
+}
+
+// FetchAgentVersions returns a map of agent identifier → version string for
+// the image identified by img@digest. The lookup is driven entirely by the
+// registry: it walks the OCI Referrers index for any attached SPDX SBOM
+// artifacts (claude, opencode) and reads the OCI image config blob for the
+// copilot LABEL. No image layers are downloaded.
+//
+// An empty map means the registry returned no usable metadata — callers
+// should treat that as "unknown versions, display nothing", not a hard
+// failure. The function never returns an error: registry weirdness is
+// quietly absorbed so the caller's UX (a Y/n pull prompt) is never blocked
+// by metadata lookups.
+func FetchAgentVersions(ctx context.Context, img, digest string) map[string]string {
+	out := map[string]string{}
+	if digest == "" {
+		return out
+	}
+	registry, repo, _ := parseImageRef(img)
+	token, err := authForRepo(ctx, registry, repo)
+	if err != nil {
+		return out
+	}
+
+	if labels, err := fetchConfigLabels(ctx, registry, repo, digest, token); err == nil {
+		for agent, key := range agentLabels {
+			if v := labels[key]; v != "" {
+				out[agent] = v
+			}
+		}
+	}
+
+	if versions, err := fetchSBOMPackageVersions(ctx, registry, repo, digest, token); err == nil {
+		for agent, pkg := range agentSBOMPackages {
+			if v := versions[pkg]; v != "" {
+				out[agent] = v
+			}
+		}
+	}
+
+	return out
+}
+
+// authForRepo returns a bearer token suitable for talking to registry/repo, or
+// "" if the registry allows anonymous read of public manifests.
+func authForRepo(ctx context.Context, registry, repo string) (string, error) {
+	probe := fmt.Sprintf("https://%s/v2/", registry)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, probe, nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		return "", nil
+	}
+	return fetchBearerToken(ctx, resp.Header.Get("Www-Authenticate"), repo)
+}
+
+// fetchConfigLabels resolves the manifest at digest, walks through to the
+// image config blob, and returns its labels map.
+//
+// For multi-arch images the top-level manifest is an index — we follow the
+// first manifest descriptor in the list (the linux platform our Dockerfile
+// builds for) and fetch its config from there.
+func fetchConfigLabels(ctx context.Context, registry, repo, digest, token string) (map[string]string, error) {
+	manifest, mediaType, err := fetchManifest(ctx, registry, repo, digest, token)
+	if err != nil {
+		return nil, err
+	}
+
+	if isIndexMediaType(mediaType) {
+		var idx struct {
+			Manifests []struct {
+				Digest    string `json:"digest"`
+				MediaType string `json:"mediaType"`
+				Platform  struct {
+					OS           string `json:"os"`
+					Architecture string `json:"architecture"`
+				} `json:"platform"`
+			} `json:"manifests"`
+		}
+		if err := json.Unmarshal(manifest, &idx); err != nil {
+			return nil, fmt.Errorf("parsing image index: %w", err)
+		}
+		var pick string
+		for _, m := range idx.Manifests {
+			if m.Platform.OS == "linux" && pick == "" {
+				pick = m.Digest
+				break
+			}
+		}
+		if pick == "" {
+			return nil, fmt.Errorf("no linux manifest in image index")
+		}
+		return fetchConfigLabels(ctx, registry, repo, pick, token)
+	}
+
+	var mf struct {
+		Config struct {
+			Digest string `json:"digest"`
+		} `json:"config"`
+	}
+	if err := json.Unmarshal(manifest, &mf); err != nil {
+		return nil, fmt.Errorf("parsing image manifest: %w", err)
+	}
+	if mf.Config.Digest == "" {
+		return nil, fmt.Errorf("manifest has no config descriptor")
+	}
+
+	blob, err := fetchBlob(ctx, registry, repo, mf.Config.Digest, token)
+	if err != nil {
+		return nil, err
+	}
+	var cfg struct {
+		Config struct {
+			Labels map[string]string `json:"Labels"`
+		} `json:"config"`
+	}
+	if err := json.Unmarshal(blob, &cfg); err != nil {
+		return nil, fmt.Errorf("parsing image config: %w", err)
+	}
+	return cfg.Config.Labels, nil
+}
+
+// fetchSBOMPackageVersions returns a map of npm-style package name → version
+// extracted from the SPDX SBOM that buildx attaches as an OCI referrer of
+// digest. Returns an empty (non-nil) map when no SBOM is attached.
+func fetchSBOMPackageVersions(ctx context.Context, registry, repo, digest, token string) (map[string]string, error) {
+	descriptors, err := fetchReferrers(ctx, registry, repo, digest, token)
+	if err != nil {
+		return nil, err
+	}
+
+	out := map[string]string{}
+	for _, ref := range descriptors {
+		// Buildx attaches the SBOM as an OCI image manifest whose layers carry
+		// the SPDX JSON. The referrer's `artifactType` is set on the manifest
+		// itself; the SPDX blob is the first layer.
+		sbomManifest, _, err := fetchManifest(ctx, registry, repo, ref.Digest, token)
+		if err != nil {
+			continue
+		}
+		var mf struct {
+			ArtifactType string `json:"artifactType"`
+			Layers       []struct {
+				Digest    string `json:"digest"`
+				MediaType string `json:"mediaType"`
+			} `json:"layers"`
+		}
+		if err := json.Unmarshal(sbomManifest, &mf); err != nil {
+			continue
+		}
+		if !isSBOMArtifactType(ref.ArtifactType) && !isSBOMArtifactType(mf.ArtifactType) {
+			// Could be a provenance attestation or some other referrer; skip.
+			continue
+		}
+		for _, layer := range mf.Layers {
+			if !isSPDXMediaType(layer.MediaType) {
+				continue
+			}
+			blob, err := fetchBlob(ctx, registry, repo, layer.Digest, token)
+			if err != nil {
+				continue
+			}
+			extractSPDXVersions(blob, out)
+		}
+	}
+
+	// For multi-arch images the top-level index may have no referrers — the
+	// SBOM is attached per platform. Fall back to the linux manifest.
+	if len(out) == 0 {
+		idxBody, mediaType, err := fetchManifest(ctx, registry, repo, digest, token)
+		if err == nil && isIndexMediaType(mediaType) {
+			var idx struct {
+				Manifests []struct {
+					Digest   string `json:"digest"`
+					Platform struct {
+						OS string `json:"os"`
+					} `json:"platform"`
+				} `json:"manifests"`
+			}
+			if err := json.Unmarshal(idxBody, &idx); err == nil {
+				for _, m := range idx.Manifests {
+					if m.Platform.OS != "linux" {
+						continue
+					}
+					if sub, err := fetchSBOMPackageVersions(ctx, registry, repo, m.Digest, token); err == nil && len(sub) > 0 {
+						return sub, nil
+					}
+				}
+			}
+		}
+	}
+
+	return out, nil
+}
+
+type referrerDescriptor struct {
+	Digest       string `json:"digest"`
+	MediaType    string `json:"mediaType"`
+	ArtifactType string `json:"artifactType"`
+}
+
+func fetchReferrers(ctx context.Context, registry, repo, digest, token string) ([]referrerDescriptor, error) {
+	url := fmt.Sprintf("https://%s/v2/%s/referrers/%s", registry, repo, digest)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/vnd.oci.image.index.v1+json")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("referrers %s: %s", url, resp.Status)
+	}
+	var idx struct {
+		Manifests []referrerDescriptor `json:"manifests"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&idx); err != nil {
+		return nil, fmt.Errorf("parsing referrers: %w", err)
+	}
+	return idx.Manifests, nil
+}
+
+func fetchManifest(ctx context.Context, registry, repo, ref, token string) ([]byte, string, error) {
+	url := fmt.Sprintf("https://%s/v2/%s/manifests/%s", registry, repo, ref)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, "", err
+	}
+	req.Header.Set("Accept", strings.Join([]string{
+		"application/vnd.oci.image.index.v1+json",
+		"application/vnd.docker.distribution.manifest.list.v2+json",
+		"application/vnd.oci.image.manifest.v1+json",
+		"application/vnd.docker.distribution.manifest.v2+json",
+	}, ", "))
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, "", fmt.Errorf("manifest %s: %s", url, resp.Status)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, "", err
+	}
+	return body, resp.Header.Get("Content-Type"), nil
+}
+
+func fetchBlob(ctx context.Context, registry, repo, digest, token string) ([]byte, error) {
+	url := fmt.Sprintf("https://%s/v2/%s/blobs/%s", registry, repo, digest)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("blob %s: %s", url, resp.Status)
+	}
+	return io.ReadAll(resp.Body)
+}
+
+// extractSPDXVersions populates out with name→version for every package in
+// the SPDX JSON document. Only the minimal subset of SPDX is read.
+func extractSPDXVersions(spdxJSON []byte, out map[string]string) {
+	var doc struct {
+		Packages []struct {
+			Name        string `json:"name"`
+			VersionInfo string `json:"versionInfo"`
+		} `json:"packages"`
+	}
+	if err := json.Unmarshal(spdxJSON, &doc); err != nil {
+		return
+	}
+	for _, p := range doc.Packages {
+		if p.Name == "" || p.VersionInfo == "" {
+			continue
+		}
+		out[p.Name] = p.VersionInfo
+	}
+}
+
+func isIndexMediaType(mt string) bool {
+	mt = strings.SplitN(mt, ";", 2)[0]
+	return mt == "application/vnd.oci.image.index.v1+json" ||
+		mt == "application/vnd.docker.distribution.manifest.list.v2+json"
+}
+
+func isSBOMArtifactType(mt string) bool {
+	mt = strings.SplitN(mt, ";", 2)[0]
+	return strings.Contains(mt, "spdx") || strings.Contains(mt, "cyclonedx") ||
+		mt == "application/vnd.in-toto+json"
+}
+
+func isSPDXMediaType(mt string) bool {
+	mt = strings.SplitN(mt, ";", 2)[0]
+	return strings.Contains(mt, "spdx") || mt == "application/json"
+}

--- a/site/content/docs/flags.md
+++ b/site/content/docs/flags.md
@@ -29,6 +29,17 @@ kpil [flags]
 | `-i`, `--interactive` | `false` | Prompt for runtime parameters before launching |
 | `--skill` | — | Bake an agent skill into the image at build time (requires `--build`) |
 
+## Environment variables
+
+| Variable | Effect |
+|---|---|
+| `GH_TOKEN` | GitHub PAT with the `copilot` scope. Required with `--agent copilot`. |
+| `ANTHROPIC_API_KEY` | Forwarded to the container. Optional with `--agent claude` (subscription login is preferred); accepted by `--agent opencode`. |
+| `OPENAI_API_KEY` | Forwarded to the container for `--agent opencode`. |
+| `KPIL_SKIP_UPDATE_CHECK` | When set to a non-empty truthy value (`1`, `true`, `yes`, …), disable the [startup update check](image.md#startup-update-check) and its Y/n prompt. |
+| `KUBECONFIG` | Used as the default for `--kubeconfig`. |
+| `DOCKER_HOST` | Honored by the runtime auto-detection (must be a `unix://` socket). |
+
 ## Examples
 
 ```sh
@@ -58,4 +69,7 @@ GH_TOKEN=$GH_TOKEN kpil --build
 
 # Interactive setup
 kpil -i
+
+# Skip the startup "image is newer" prompt (CI, offline use)
+KPIL_SKIP_UPDATE_CHECK=1 kpil
 ```

--- a/site/content/docs/image.md
+++ b/site/content/docs/image.md
@@ -53,6 +53,54 @@ The image is built for `linux/amd64` and `linux/arm64`.
 
 The entrypoint dispatches to the right agent at runtime based on the `AGENT` environment variable set by kpil (mirroring `--agent`).
 
+## Startup update check
+
+When you run `kpil` against an image already present locally (no `--pull`, no
+`--build`), kpil queries the registry for the current manifest digest and
+compares it against the local image. If they differ, kpil also reads the
+image's baked-in agent versions from the registry without pulling any layers
+— the SBOM attached by buildx for `claude` / `opencode`, and the OCI label
+for `copilot` — and prints both sides side-by-side before prompting:
+
+```
+Image ghcr.io/qjoly/kpil:nightly found locally.
+A newer version of ghcr.io/qjoly/kpil:nightly is available in the registry.
+  local digest:  sha256:b79290…
+  remote digest: sha256:443df4…
+  baked-in agent versions:
+  → claude    2.0.4   →  2.1.173
+      opencode  1.16.0  →  1.17.3
+      copilot   1.0.35  →  1.0.35
+Pull the latest version now? [Y/n]:
+```
+
+Answer `Y` (or just Enter) to pull the new image in place; answer `n` to keep
+the local version. `Ctrl+C` cancels both the prompt and the run.
+
+A locally-built image (`--build`) carries no registry-bound digest, so the
+check skips silently. Same goes for images whose registry returns no digest
+header.
+
+### Disabling the check
+
+Set `KPIL_SKIP_UPDATE_CHECK=1` in the environment to skip the check
+entirely — useful in CI, offline environments, or any flow where the
+prompt would block:
+
+```sh
+export KPIL_SKIP_UPDATE_CHECK=1
+kpil
+```
+
+Equivalent on a single invocation:
+
+```sh
+KPIL_SKIP_UPDATE_CHECK=1 kpil
+```
+
+The check is unaffected when `--pull` or `--build` is set: those flags
+already force a specific image state.
+
 ## Signature verification
 
 Every image is signed with [cosign keyless signing](https://docs.sigstore.dev/cosign/signing/overview/) via GitHub Actions OIDC. The CLI verifies the signature automatically before starting the container.


### PR DESCRIPTION
At startup, when the configured image is already present locally,
compare its local digest against the registry's current digest. On a
mismatch, surface a Y/n prompt before launching so the user can pull
in-place without restarting kpil with --pull.

Falls back to direct registry HTTP for digest lookup so podman-exec
backends and multi-arch manifest lists work uniformly (the per-platform
manifest-inspect output is not enough on its own).

To make the prompt actionable, also surface the baked-in agent
versions on both sides of the diff:

  * Attach an SPDX SBOM via docker/build-push-action sbom: true on
    ci.yml, nightly.yml, and release.yml. syft auto-detects the
    npm-installed claude-code and opencode-ai packages.
  * Promote the pinned Copilot CLI version to an ARG and expose it
    via an OCI LABEL — syft does not see the raw binary download.
  * Read both sides from the registry without pulling layers: SBOM
    via the OCI Referrers API, copilot label via the image config
    blob, following multi-arch index manifests through to a linux
    platform manifest.

Signal handling tightened so a single ^C at the prompt unblocks the
stdin read and exits cleanly; a second ^C now force-exits via
signal.Reset.