### PR TITLE
fix(staleness): address code-review findings + add tests

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -233,15 +233,23 @@ func run(cmd *cobra.Command, _ []string) error {
 	}
 
 	// ---- signal handling -----------------------------------------------
-	// First signal triggers graceful cancellation; the second restores the
-	// default handler so an impatient user can always force-exit with ^C^C.
-	sigCh := make(chan os.Signal, 1)
+	// First signal cancels the context so the rest of the program can wind
+	// down through its deferred cleanup (RBAC removal, kubeconfig delete).
+	// A second signal force-exits with a warning that those defers were not
+	// allowed to finish — we explicitly do NOT use signal.Reset on the first
+	// signal because that lets a follow-up ^C kill the process via the
+	// default handler, silently skipping the cleanup that protects against
+	// stale ServiceAccount tokens on disk.
+	sigCh := make(chan os.Signal, 2)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
-		<-sigCh
-		fmt.Fprintln(os.Stderr, "\nSignal received — cleaning up…")
+		sig := <-sigCh
+		fmt.Fprintf(os.Stderr, "\n%s received — cleaning up… (^C again to abort)\n", sig)
 		cancel()
-		signal.Reset(syscall.SIGINT, syscall.SIGTERM)
+		sig = <-sigCh
+		fmt.Fprintf(os.Stderr, "\n%s received again — aborting cleanup. RBAC objects and %s may remain; remove with:\n  kubectl delete clusterrolebinding,clusterrole,sa -l app=%s -A\n  rm -f %s\n",
+			sig, cfg.OutKubeconfig, cfg.SAName, cfg.OutKubeconfig)
+		os.Exit(130)
 	}()
 
 	// ---- Kubernetes client ---------------------------------------------
@@ -316,7 +324,7 @@ func run(cmd *cobra.Command, _ []string) error {
 		}
 		if exists {
 			fmt.Printf("Image %s found locally.\n", cfg.Image)
-			pulled, err := maybePullIfStale(ctx, ctr, cfg.Image)
+			pulled, err := maybePullIfStale(ctx, ctr, cfg.Runtime, cfg.Image)
 			switch {
 			case errors.Is(err, context.Canceled):
 				return nil
@@ -397,11 +405,18 @@ func run(cmd *cobra.Command, _ []string) error {
 // the lookup, the KPIL_SKIP_UPDATE_CHECK env var is set, or stdin isn't a
 // TTY (no way to prompt). Registry/inspect errors propagate so the caller
 // can surface a warning.
-func maybePullIfStale(ctx context.Context, ctr container.Client, img string) (bool, error) {
+func maybePullIfStale(ctx context.Context, ctr container.Client, runtime, img string) (bool, error) {
 	if skipUpdateCheck() {
 		return false, nil
 	}
-	local, err := ctr.LocalDigest(ctx, img)
+	// Bound the staleness probes so a hung registry or blackholing proxy
+	// can't wedge CLI startup indefinitely. The whole interactive prompt
+	// would never be reached if any of these calls blocks forever — the
+	// outer cobra context has no deadline of its own.
+	checkCtx, cancelCheck := context.WithTimeout(ctx, 10*time.Second)
+	defer cancelCheck()
+
+	local, err := ctr.LocalDigest(checkCtx, img)
 	if err != nil {
 		return false, fmt.Errorf("reading local digest: %w", err)
 	}
@@ -410,7 +425,7 @@ func maybePullIfStale(ctx context.Context, ctr container.Client, img string) (bo
 		// nothing meaningful to compare against, skip silently.
 		return false, nil
 	}
-	remote, err := ctr.RemoteDigest(ctx, img)
+	remote, err := ctr.RemoteDigest(checkCtx, img)
 	if err != nil {
 		return false, fmt.Errorf("reading remote digest: %w", err)
 	}
@@ -422,14 +437,14 @@ func maybePullIfStale(ctx context.Context, ctr container.Client, img string) (bo
 	// false-positive on every multi-arch tag. Treat the local image as
 	// up-to-date when its digest is the current arch's child of the remote
 	// index (or vice versa).
-	if container.SameImage(ctx, img, local, remote) {
+	if container.SameImage(checkCtx, img, local, remote) {
 		return false, nil
 	}
 
 	fmt.Printf("A newer version of %s is available in the registry.\n", img)
 	fmt.Printf("  local digest:  %s\n", local)
 	fmt.Printf("  remote digest: %s\n", remote)
-	printAgentVersionDiff(ctx, img, local, remote)
+	printAgentVersionDiff(ctx, runtime, img, local, remote)
 
 	if !term.IsTerminal(int(os.Stdin.Fd())) {
 		fmt.Println("  Stdin is not a TTY — keeping the local image. Re-run with --pull to update.")
@@ -455,6 +470,18 @@ func maybePullIfStale(ctx context.Context, ctr container.Client, img string) (bo
 		return false, fmt.Errorf("pulling latest image: %w", err)
 	}
 	return true, nil
+}
+
+// needsLocalProbe reports whether at least one of the tracked agents lacks a
+// version after the registry lookup, in which case the container probe is
+// worth its ~1-2 s of latency.
+func needsLocalProbe(versions map[string]string) bool {
+	for _, agent := range []string{"claude", "opencode", "copilot"} {
+		if versions[agent] == "" {
+			return true
+		}
+	}
+	return false
 }
 
 // skipUpdateCheck reports whether the startup staleness check should be
@@ -495,20 +522,19 @@ func readLineCtx(ctx context.Context, r io.Reader) (string, error) {
 // both the local and remote image (SBOM for claude/opencode, OCI label for
 // copilot) and prints a table when at least one side reports a version.
 // Failures are silent: the digest mismatch is already informative on its own.
-func printAgentVersionDiff(ctx context.Context, img, localDigest, remoteDigest string) {
+func printAgentVersionDiff(ctx context.Context, runtime, img, localDigest, remoteDigest string) {
 	// 20 s budget split across two registry lookups (each potentially fetching
 	// a multi-MB SBOM blob) plus an optional local-container probe.
 	vCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
 	defer cancel()
 
-	// Local registry lookup, remote registry lookup, and the local-container
-	// fallback can all run concurrently — none depend on each other's
-	// results — so we never pay the cost of their sum on the wall clock.
+	// Local and remote registry lookups run in parallel — they don't depend
+	// on each other and they don't depend on the local-container probe.
 	var (
-		localVersions, remoteVersions, fallbackVersions map[string]string
-		wg                                              sync.WaitGroup
+		localVersions, remoteVersions map[string]string
+		wg                            sync.WaitGroup
 	)
-	wg.Add(3)
+	wg.Add(2)
 	go func() {
 		defer wg.Done()
 		localVersions = container.FetchAgentVersions(vCtx, img, localDigest)
@@ -517,20 +543,21 @@ func printAgentVersionDiff(ctx context.Context, img, localDigest, remoteDigest s
 		defer wg.Done()
 		remoteVersions = container.FetchAgentVersions(vCtx, img, remoteDigest)
 	}()
-	go func() {
-		defer wg.Done()
-		fallbackVersions = container.LocalAgentVersions(vCtx, img)
-	}()
 	wg.Wait()
 	if localVersions == nil {
 		localVersions = map[string]string{}
 	}
 
-	// Merge the local-container probe results, but only as fallback values:
-	// the registry-side SBOM/label is canonical when present.
-	for k, v := range fallbackVersions {
-		if localVersions[k] == "" {
-			localVersions[k] = v
+	// Only spin up a container to probe agent versions when the registry SBOM
+	// didn't surface them. On post-SBOM images the registry path returns
+	// everything we need and we skip a costly `<runtime> run --rm` (1-2 s on
+	// Apple Silicon emulating linux/amd64).
+	if needsLocalProbe(localVersions) {
+		fallback := container.LocalAgentVersions(vCtx, runtime, img)
+		for k, v := range fallback {
+			if localVersions[k] == "" {
+				localVersions[k] = v
+			}
 		}
 	}
 

--- a/internal/container/client.go
+++ b/internal/container/client.go
@@ -159,10 +159,12 @@ func canDial(path string) bool {
 }
 
 // digestForImage extracts the manifest digest matching img from a list of
-// repo digests of the form "repo@sha256:…". It first looks for the entry whose
-// repo prefix matches img (so we ignore digests for unrelated tags pulled into
-// the same image ID); if none matches, the first available digest is returned.
-// Returns "" when the list is empty (image built locally, never pushed/pulled).
+// repo digests of the form "repo@sha256:…". It looks for the entry whose
+// repo prefix matches img so we ignore digests for unrelated repos pulled
+// into the same image ID (a `docker tag` that points two repos at the same
+// content would otherwise let us hand back the wrong registry's digest).
+// Returns "" when no entry matches — the caller treats that as "unknown
+// local digest, skip the staleness check silently".
 func digestForImage(img string, repoDigests []string) string {
 	repoPrefix := img
 	if i := strings.Index(repoPrefix, "@"); i >= 0 {
@@ -174,11 +176,6 @@ func digestForImage(img string, repoDigests []string) string {
 	for _, rd := range repoDigests {
 		if strings.HasPrefix(rd, repoPrefix+"@") {
 			return strings.SplitN(rd, "@", 2)[1]
-		}
-	}
-	if len(repoDigests) > 0 {
-		if parts := strings.SplitN(repoDigests[0], "@", 2); len(parts) == 2 {
-			return parts[1]
 		}
 	}
 	return ""

--- a/internal/container/client_test.go
+++ b/internal/container/client_test.go
@@ -1,0 +1,120 @@
+package container
+
+import "testing"
+
+func TestDigestForImage(t *testing.T) {
+	const wantedDigest = "sha256:aaaa"
+	const otherDigest = "sha256:bbbb"
+
+	tests := []struct {
+		name        string
+		img         string
+		repoDigests []string
+		want        string
+	}{
+		{
+			name:        "empty list returns empty",
+			img:         "ghcr.io/qjoly/kpil:latest",
+			repoDigests: nil,
+			want:        "",
+		},
+		{
+			name:        "matches repo prefix",
+			img:         "ghcr.io/qjoly/kpil:latest",
+			repoDigests: []string{"ghcr.io/qjoly/kpil@" + wantedDigest},
+			want:        wantedDigest,
+		},
+		{
+			name:        "ignores tag when matching",
+			img:         "ghcr.io/qjoly/kpil:nightly",
+			repoDigests: []string{"ghcr.io/qjoly/kpil@" + wantedDigest},
+			want:        wantedDigest,
+		},
+		{
+			name:        "strips digest from img when matching",
+			img:         "ghcr.io/qjoly/kpil@sha256:cccc",
+			repoDigests: []string{"ghcr.io/qjoly/kpil@" + wantedDigest},
+			want:        wantedDigest,
+		},
+		{
+			name: "picks the right repo when multiple are present",
+			img:  "ghcr.io/qjoly/kpil:latest",
+			repoDigests: []string{
+				"docker.io/library/other@" + otherDigest,
+				"ghcr.io/qjoly/kpil@" + wantedDigest,
+			},
+			want: wantedDigest,
+		},
+		{
+			name: "returns empty when nothing matches (A5 fix)",
+			img:  "internal-mirror.example/kpil:dev",
+			repoDigests: []string{
+				"ghcr.io/qjoly/kpil@" + otherDigest,
+			},
+			want: "",
+		},
+		{
+			name:        "handles registry:port in img",
+			img:         "localhost:5000/foo:tag",
+			repoDigests: []string{"localhost:5000/foo@" + wantedDigest},
+			want:        wantedDigest,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := digestForImage(tc.img, tc.repoDigests)
+			if got != tc.want {
+				t.Fatalf("digestForImage(%q, %v) = %q, want %q", tc.img, tc.repoDigests, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseImageRef(t *testing.T) {
+	tests := []struct {
+		img      string
+		registry string
+		repo     string
+		ref      string
+	}{
+		{"ghcr.io/qjoly/kpil:latest", "ghcr.io", "qjoly/kpil", "latest"},
+		{"ghcr.io/qjoly/kpil:nightly", "ghcr.io", "qjoly/kpil", "nightly"},
+		{"ghcr.io/qjoly/kpil@sha256:abc", "ghcr.io", "qjoly/kpil", "sha256:abc"},
+		{"localhost:5000/foo:tag", "localhost:5000", "foo", "tag"},
+		{"localhost:5000/foo", "localhost:5000", "foo", "latest"},
+		{"alpine", "registry-1.docker.io", "library/alpine", "latest"},
+		{"library/alpine:3.18", "registry-1.docker.io", "library/alpine", "3.18"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.img, func(t *testing.T) {
+			registry, repo, ref := parseImageRef(tc.img)
+			if registry != tc.registry || repo != tc.repo || ref != tc.ref {
+				t.Fatalf("parseImageRef(%q) = (%q, %q, %q), want (%q, %q, %q)",
+					tc.img, registry, repo, ref, tc.registry, tc.repo, tc.ref)
+			}
+		})
+	}
+}
+
+func TestIsImageNotFoundStderr(t *testing.T) {
+	tests := []struct {
+		stderr string
+		want   bool
+	}{
+		{"Error: No such image: ghcr.io/qjoly/kpil:nightly", true},
+		{"Error response from daemon: no such image: foo", true},
+		{"Error: image not known: foo", true},
+		{"manifest unknown", true},
+		{"Error response from daemon: Get \"http://...\": dial tcp: connect: connection refused", false},
+		{"permission denied while trying to connect to the Docker daemon socket", false},
+		{"", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.stderr, func(t *testing.T) {
+			got := isImageNotFoundStderr(tc.stderr)
+			if got != tc.want {
+				t.Fatalf("isImageNotFoundStderr(%q) = %v, want %v", tc.stderr, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/container/exec.go
+++ b/internal/container/exec.go
@@ -38,22 +38,41 @@ func (e *execClient) ImageExists(_ context.Context, img string) (bool, error) {
 }
 
 // LocalDigest returns the manifest digest recorded in RepoDigests for the
-// locally stored image. Returns "" if the image was built locally and has no
-// associated registry digest.
-func (e *execClient) LocalDigest(_ context.Context, img string) (string, error) {
-	cmd := exec.Command(e.runtime, "image", "inspect", "--format", "{{json .RepoDigests}}", img)
+// locally stored image. Returns "" if the image is not present locally or
+// was built locally and has no associated registry digest.
+//
+// We distinguish "image not present" (a benign skip — the prior ImageExists
+// branch races could remove the image between calls) from real backend
+// failures (daemon down, socket permission denied, malformed runtime
+// output) by inspecting the CLI's stderr: docker/podman both prefix
+// not-found errors with literal "No such image" / "image not known".
+func (e *execClient) LocalDigest(ctx context.Context, img string) (string, error) {
+	var stderr bytes.Buffer
+	cmd := exec.CommandContext(ctx, e.runtime, "image", "inspect", "--format", "{{json .RepoDigests}}", img)
+	cmd.Stderr = &stderr
 	out, err := cmd.Output()
 	if err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() != 0 {
+		stderrText := stderr.String()
+		if isImageNotFoundStderr(stderrText) {
 			return "", nil
 		}
-		return "", fmt.Errorf("inspecting image %s: %w", img, err)
+		return "", fmt.Errorf("inspecting image %s: %w (stderr: %s)", img, err, strings.TrimSpace(stderrText))
 	}
 	var repoDigests []string
 	if err := json.Unmarshal(bytes.TrimSpace(out), &repoDigests); err != nil {
 		return "", fmt.Errorf("parsing repo digests for %s: %w", img, err)
 	}
 	return digestForImage(img, repoDigests), nil
+}
+
+// isImageNotFoundStderr matches the stable substrings docker and podman emit
+// when an image is absent. Kept as a free function so tests can pin the
+// exact wording.
+func isImageNotFoundStderr(s string) bool {
+	s = strings.ToLower(s)
+	return strings.Contains(s, "no such image") ||
+		strings.Contains(s, "image not known") ||
+		strings.Contains(s, "manifest unknown")
 }
 
 // RemoteDigest fetches the current manifest digest for img directly from its

--- a/internal/container/local_versions.go
+++ b/internal/container/local_versions.go
@@ -12,6 +12,13 @@ import (
 // stored image by running it briefly with a no-op entrypoint and parsing the
 // `--version` output of each agent binary.
 //
+// preferredRuntime should be the same runtime kpil chose elsewhere (the
+// --runtime flag, or "" to auto-detect). Threading it through avoids the
+// case where the user passes --runtime podman but the host also has a
+// docker binary earlier in PATH — without the preference, this probe
+// would run against a different runtime than the image was pulled into
+// and silently come back empty.
+//
 // This is the fallback for the on-startup version diff when the local image
 // has no SBOM attached (e.g. it was pulled before kpil's CI started
 // publishing SBOMs, or it was built with `--build`).
@@ -19,8 +26,8 @@ import (
 // Returns an empty map if no runtime CLI is available or the container
 // failed to start — silent failure is fine because the caller already has
 // the digest diff to show.
-func LocalAgentVersions(ctx context.Context, img string) map[string]string {
-	rt, err := detectRuntimeCLI("")
+func LocalAgentVersions(ctx context.Context, preferredRuntime, img string) map[string]string {
+	rt, err := detectRuntimeCLI(preferredRuntime)
 	if err != nil {
 		return nil
 	}

--- a/internal/container/local_versions_test.go
+++ b/internal/container/local_versions_test.go
@@ -1,0 +1,61 @@
+package container
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseAgentVersionLines(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want map[string]string
+	}{
+		{
+			name: "all three agents present",
+			in:   "claude=2.1.173\nopencode=1.17.3\ncopilot=1.0.35\n",
+			want: map[string]string{
+				"claude":   "2.1.173",
+				"opencode": "1.17.3",
+				"copilot":  "1.0.35",
+			},
+		},
+		{
+			name: "version embedded in noise text",
+			in:   "claude=Claude Code 2.1.173 (build abc)\nopencode=opencode 1.17.3-rc.2\ncopilot=GitHub Copilot CLI v1.0.35\n",
+			want: map[string]string{
+				"claude":   "2.1.173",
+				"opencode": "1.17.3-rc.2",
+				"copilot":  "1.0.35",
+			},
+		},
+		{
+			name: "missing agent is silently dropped",
+			in:   "claude=\nopencode=1.17.3\ncopilot=1.0.35\n",
+			want: map[string]string{
+				"opencode": "1.17.3",
+				"copilot":  "1.0.35",
+			},
+		},
+		{
+			name: "completely empty output returns nil",
+			in:   "",
+			want: nil,
+		},
+		{
+			name: "lines without = are ignored",
+			in:   "this is not a version\nclaude=2.1.173\n",
+			want: map[string]string{
+				"claude": "2.1.173",
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseAgentVersionLines([]byte(tc.in))
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("parseAgentVersionLines(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/container/registry.go
+++ b/internal/container/registry.go
@@ -70,6 +70,17 @@ func manifestHead(ctx context.Context, url, bearer string) (string, error) {
 	if resp.StatusCode == http.StatusUnauthorized {
 		return "", &authChallenge{header: resp.Header.Get("Www-Authenticate")}
 	}
+	if resp.StatusCode == http.StatusNotFound {
+		// The tag isn't reachable at this registry. Two main shapes:
+		//   1. A genuine 404 (tag deleted, name typo).
+		//   2. parseImageRef misrouting a single-label hostname to Docker Hub
+		//      because the docker convention requires a dot, colon, or
+		//      "localhost" in the first segment to recognize a registry.
+		// In both cases we'd rather skip the staleness check silently than
+		// scream "could not check for a newer image" on every kpil startup
+		// — the user pulled the image successfully, that's enough.
+		return "", nil
+	}
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("registry returned %s for %s", resp.Status, url)
 	}

--- a/internal/container/registry_test.go
+++ b/internal/container/registry_test.go
@@ -1,0 +1,304 @@
+package container
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// mockRegistry serves a minimal subset of the v2 distribution spec sufficient
+// to exercise fetchRegistryDigest, fetchConfigLabels, fetchAttestationSBOM,
+// SameImage, and FetchAgentVersions against an httptest.Server.
+type mockRegistry struct {
+	t          *testing.T
+	indexDigest string
+	indexBody   []byte
+	manifests  map[string][]byte // digest → raw manifest body
+	blobs      map[string][]byte // digest → raw blob body
+	mediaTypes map[string]string // digest → Content-Type for HEAD/GET responses
+	requestLog []string
+}
+
+func newMockRegistry(t *testing.T) *mockRegistry {
+	return &mockRegistry{
+		t:          t,
+		manifests:  map[string][]byte{},
+		blobs:      map[string][]byte{},
+		mediaTypes: map[string]string{},
+	}
+}
+
+func (m *mockRegistry) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	m.requestLog = append(m.requestLog, r.Method+" "+r.URL.Path)
+	switch {
+	case r.URL.Path == "/v2/":
+		w.WriteHeader(http.StatusOK)
+	case strings.HasPrefix(r.URL.Path, "/v2/") && strings.Contains(r.URL.Path, "/manifests/"):
+		ref := r.URL.Path[strings.LastIndex(r.URL.Path, "/")+1:]
+		body, ok := m.manifests[ref]
+		if !ok && ref == "latest" {
+			body = m.indexBody
+			ok = body != nil
+		}
+		if !ok {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", m.mediaTypes[ref])
+		w.Header().Set("Docker-Content-Digest", m.digestFor(ref))
+		if r.Method == http.MethodHead {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	case strings.HasPrefix(r.URL.Path, "/v2/") && strings.Contains(r.URL.Path, "/blobs/"):
+		ref := r.URL.Path[strings.LastIndex(r.URL.Path, "/")+1:]
+		body, ok := m.blobs[ref]
+		if !ok {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/octet-stream")
+		_, _ = w.Write(body)
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func (m *mockRegistry) digestFor(ref string) string {
+	if ref == "latest" {
+		return m.indexDigest
+	}
+	return ref
+}
+
+// buildBuildxStyleImage wires a multi-arch image with an in-toto/SPDX SBOM
+// attestation-manifest, mirroring what buildx push --sbom=true produces on
+// GHCR. Returns the index digest.
+func (m *mockRegistry) buildBuildxStyleImage(copilotVersion string, sbomPackages map[string]string) string {
+	// Image config blob (carries the copilot LABEL).
+	cfg := map[string]any{
+		"config": map[string]any{
+			"Labels": map[string]string{
+				"org.kpil.copilot.version": copilotVersion,
+			},
+		},
+	}
+	cfgBlob, _ := json.Marshal(cfg)
+	const cfgDigest = "sha256:config000"
+	m.blobs[cfgDigest] = cfgBlob
+
+	// linux/amd64 image manifest.
+	imageManifest := map[string]any{
+		"schemaVersion": 2,
+		"mediaType":     "application/vnd.oci.image.manifest.v1+json",
+		"config": map[string]any{
+			"mediaType": "application/vnd.oci.image.config.v1+json",
+			"digest":    cfgDigest,
+			"size":      len(cfgBlob),
+		},
+	}
+	imageBody, _ := json.Marshal(imageManifest)
+	const imageDigest = "sha256:image0000amd64"
+	m.manifests[imageDigest] = imageBody
+	m.mediaTypes[imageDigest] = "application/vnd.oci.image.manifest.v1+json"
+
+	// Build an SPDX in-toto statement carrying the requested packages.
+	var spdxPkgs []map[string]string
+	for name, ver := range sbomPackages {
+		spdxPkgs = append(spdxPkgs, map[string]string{
+			"name":        name,
+			"versionInfo": ver,
+		})
+	}
+	statement := map[string]any{
+		"_type":         "https://in-toto.io/Statement/v0.1",
+		"predicateType": "https://spdx.dev/Document",
+		"predicate": map[string]any{
+			"spdxVersion": "SPDX-2.3",
+			"packages":    spdxPkgs,
+		},
+	}
+	statementBlob, _ := json.Marshal(statement)
+	const statementDigest = "sha256:spdx0000statement"
+	m.blobs[statementDigest] = statementBlob
+
+	// Attestation manifest referencing the linux/amd64 image.
+	attestManifest := map[string]any{
+		"schemaVersion": 2,
+		"mediaType":     "application/vnd.oci.image.manifest.v1+json",
+		"layers": []map[string]any{
+			{
+				"mediaType": "application/vnd.in-toto+json",
+				"digest":    statementDigest,
+				"size":      len(statementBlob),
+				"annotations": map[string]string{
+					"in-toto.io/predicate-type": "https://spdx.dev/Document",
+				},
+			},
+		},
+	}
+	attestBody, _ := json.Marshal(attestManifest)
+	const attestDigest = "sha256:attest0000amd64"
+	m.manifests[attestDigest] = attestBody
+	m.mediaTypes[attestDigest] = "application/vnd.oci.image.manifest.v1+json"
+
+	// Top-level OCI image index that ties them together.
+	index := map[string]any{
+		"schemaVersion": 2,
+		"mediaType":     "application/vnd.oci.image.index.v1+json",
+		"manifests": []map[string]any{
+			{
+				"mediaType": "application/vnd.oci.image.manifest.v1+json",
+				"digest":    imageDigest,
+				"platform":  map[string]string{"os": "linux", "architecture": "amd64"},
+			},
+			{
+				"mediaType": "application/vnd.oci.image.manifest.v1+json",
+				"digest":    attestDigest,
+				"platform":  map[string]string{"os": "unknown", "architecture": "unknown"},
+				"annotations": map[string]string{
+					"vnd.docker.reference.type":   "attestation-manifest",
+					"vnd.docker.reference.digest": imageDigest,
+				},
+			},
+		},
+	}
+	indexBody, _ := json.Marshal(index)
+	indexDigest := "sha256:index00000nightly"
+	m.indexBody = indexBody
+	m.indexDigest = indexDigest
+	m.manifests[indexDigest] = indexBody
+	m.mediaTypes[indexDigest] = "application/vnd.oci.image.index.v1+json"
+	m.mediaTypes["latest"] = "application/vnd.oci.image.index.v1+json"
+	return indexDigest
+}
+
+func startMockRegistry(t *testing.T) (*mockRegistry, string) {
+	t.Helper()
+	reg := newMockRegistry(t)
+	srv := httptest.NewTLSServer(reg)
+	t.Cleanup(srv.Close)
+	host := strings.TrimPrefix(srv.URL, "https://")
+	// Allow the test's TLS roundtripper to skip cert verification.
+	old := http.DefaultTransport
+	http.DefaultTransport = srv.Client().Transport
+	t.Cleanup(func() { http.DefaultTransport = old })
+	return reg, host
+}
+
+func TestFetchAgentVersions_AgainstMockRegistry(t *testing.T) {
+	reg, host := startMockRegistry(t)
+	indexDigest := reg.buildBuildxStyleImage(
+		"1.0.35",
+		map[string]string{
+			"@anthropic-ai/claude-code": "2.1.173",
+			"opencode-ai":               "1.17.3",
+		},
+	)
+	img := host + "/qjoly/kpil:latest"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	versions := FetchAgentVersions(ctx, img, indexDigest)
+	if versions["copilot"] != "1.0.35" {
+		t.Errorf("copilot version: got %q, want %q", versions["copilot"], "1.0.35")
+	}
+	if versions["claude"] != "2.1.173" {
+		t.Errorf("claude version: got %q, want %q", versions["claude"], "2.1.173")
+	}
+	if versions["opencode"] != "1.17.3" {
+		t.Errorf("opencode version: got %q, want %q", versions["opencode"], "1.17.3")
+	}
+}
+
+func TestSameImage_IndexAndPerPlatformChild(t *testing.T) {
+	reg, host := startMockRegistry(t)
+	indexDigest := reg.buildBuildxStyleImage("1.0.35", map[string]string{
+		"@anthropic-ai/claude-code": "2.1.173",
+	})
+	img := host + "/qjoly/kpil:latest"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// The platform child of the index — should be reported as equivalent.
+	const platformChild = "sha256:image0000amd64"
+	if !SameImage(ctx, img, platformChild, indexDigest) {
+		t.Errorf("SameImage(local=child, remote=index) returned false; want true")
+	}
+	if !SameImage(ctx, img, indexDigest, platformChild) {
+		t.Errorf("SameImage(local=index, remote=child) returned false; want true")
+	}
+
+	// An unrelated digest must not be reported as equivalent.
+	if SameImage(ctx, img, "sha256:unrelatedxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", indexDigest) {
+		t.Errorf("SameImage with unrelated local digest returned true; want false")
+	}
+}
+
+func TestFetchRegistryDigest_404IsSilent(t *testing.T) {
+	// A registry that returns 404 for the manifest should produce ("", nil)
+	// — kpil treats this as "skip the staleness check silently" rather than
+	// emitting "could not check for a newer image" noise on every startup.
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v2/" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+	old := http.DefaultTransport
+	http.DefaultTransport = srv.Client().Transport
+	defer func() { http.DefaultTransport = old }()
+
+	host := strings.TrimPrefix(srv.URL, "https://")
+	img := host + "/some/missing:tag"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	digest, err := fetchRegistryDigest(ctx, img)
+	if err != nil {
+		t.Fatalf("fetchRegistryDigest on 404: unexpected error: %v", err)
+	}
+	if digest != "" {
+		t.Fatalf("fetchRegistryDigest on 404: got %q, want \"\"", digest)
+	}
+}
+
+func TestFetchRegistryDigest_RespectsContextTimeout(t *testing.T) {
+	// Server that hangs forever — fetchRegistryDigest must respect the ctx
+	// timeout so a flaky registry can't wedge CLI startup.
+	done := make(chan struct{})
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-done
+	}))
+	defer func() { close(done); srv.Close() }()
+	old := http.DefaultTransport
+	http.DefaultTransport = srv.Client().Transport
+	defer func() { http.DefaultTransport = old }()
+
+	host := strings.TrimPrefix(srv.URL, "https://")
+	img := host + "/some/hung:tag"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err := fetchRegistryDigest(ctx, img)
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatalf("fetchRegistryDigest against hung server returned nil error, want context.DeadlineExceeded")
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("fetchRegistryDigest blocked %v before honoring ctx timeout; want under 1s", elapsed)
+	}
+}

--- a/internal/container/sbom.go
+++ b/internal/container/sbom.go
@@ -154,62 +154,19 @@ func fetchConfigLabels(ctx context.Context, registry, repo, digest, token string
 // fetchSBOMPackageVersions returns a map of npm-style package name → version
 // extracted from the SPDX SBOM attached to the image at digest.
 //
-// Buildx with `sbom: true` does not push the SBOM via the OCI Referrers API
-// (which GHCR doesn't fully support — it 303-redirects). Instead, buildx
-// embeds an "attestation-manifest" inside the image index, one per platform,
-// referencing back to the platform image via the
+// Buildx with `sbom: true` embeds an "attestation-manifest" inside the image
+// index, one per platform, referencing back to the platform image via the
 // `vnd.docker.reference.digest` annotation. Each attestation-manifest's
 // layers are in-toto statements; the SPDX SBOM lives in the layer whose
 // `in-toto.io/predicate-type` annotation is `https://spdx.dev/Document`,
 // with the SPDX document carried inline in the statement's `predicate`
-// field.
-//
-// We optimistically try the OCI Referrers API first (works on registries
-// that support it) and fall back to scanning the image index for the
-// attestation-manifest.
+// field. GHCR (kpil's default registry) does not implement the OCI
+// Referrers API in a way buildx uses, so we don't probe it here — if a
+// future target registry needs the Referrers path it should be added back
+// as a separate, tested branch rather than dead "tried but always empty"
+// boilerplate.
 func fetchSBOMPackageVersions(ctx context.Context, registry, repo, digest, token string) (map[string]string, error) {
-	if out := tryReferrerSBOM(ctx, registry, repo, digest, token); len(out) > 0 {
-		return out, nil
-	}
 	return fetchAttestationSBOM(ctx, registry, repo, digest, token)
-}
-
-// tryReferrerSBOM probes the OCI Referrers API. Returns nil silently when
-// the registry doesn't expose referrers or none are SBOMs.
-func tryReferrerSBOM(ctx context.Context, registry, repo, digest, token string) map[string]string {
-	descriptors, err := fetchReferrers(ctx, registry, repo, digest, token)
-	if err != nil || len(descriptors) == 0 {
-		return nil
-	}
-	out := map[string]string{}
-	for _, ref := range descriptors {
-		sbomManifest, _, err := fetchManifest(ctx, registry, repo, ref.Digest, token)
-		if err != nil {
-			continue
-		}
-		var mf struct {
-			ArtifactType string `json:"artifactType"`
-			Layers       []struct {
-				Digest    string `json:"digest"`
-				MediaType string `json:"mediaType"`
-			} `json:"layers"`
-		}
-		if err := json.Unmarshal(sbomManifest, &mf); err != nil {
-			continue
-		}
-		if !isSBOMArtifactType(ref.ArtifactType) && !isSBOMArtifactType(mf.ArtifactType) {
-			continue
-		}
-		for _, layer := range mf.Layers {
-			if !isSPDXMediaType(layer.MediaType) {
-				continue
-			}
-			if blob, err := fetchBlob(ctx, registry, repo, layer.Digest, token); err == nil {
-				extractSPDXVersions(blob, out)
-			}
-		}
-	}
-	return out
 }
 
 // fetchAttestationSBOM extracts the SPDX SBOM that buildx embeds inside the
@@ -294,42 +251,6 @@ func fetchAttestationSBOM(ctx context.Context, registry, repo, digest, token str
 	return out, nil
 }
 
-type referrerDescriptor struct {
-	Digest       string `json:"digest"`
-	MediaType    string `json:"mediaType"`
-	ArtifactType string `json:"artifactType"`
-}
-
-func fetchReferrers(ctx context.Context, registry, repo, digest, token string) ([]referrerDescriptor, error) {
-	url := fmt.Sprintf("https://%s/v2/%s/referrers/%s", registry, repo, digest)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Accept", "application/vnd.oci.image.index.v1+json")
-	if token != "" {
-		req.Header.Set("Authorization", "Bearer "+token)
-	}
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode == http.StatusNotFound {
-		return nil, nil
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("referrers %s: %s", url, resp.Status)
-	}
-	var idx struct {
-		Manifests []referrerDescriptor `json:"manifests"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&idx); err != nil {
-		return nil, fmt.Errorf("parsing referrers: %w", err)
-	}
-	return idx.Manifests, nil
-}
-
 func fetchManifest(ctx context.Context, registry, repo, ref, token string) ([]byte, string, error) {
 	url := fmt.Sprintf("https://%s/v2/%s/manifests/%s", registry, repo, ref)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
@@ -404,15 +325,4 @@ func isIndexMediaType(mt string) bool {
 	mt = strings.SplitN(mt, ";", 2)[0]
 	return mt == "application/vnd.oci.image.index.v1+json" ||
 		mt == "application/vnd.docker.distribution.manifest.list.v2+json"
-}
-
-func isSBOMArtifactType(mt string) bool {
-	mt = strings.SplitN(mt, ";", 2)[0]
-	return strings.Contains(mt, "spdx") || strings.Contains(mt, "cyclonedx") ||
-		mt == "application/vnd.in-toto+json"
-}
-
-func isSPDXMediaType(mt string) bool {
-	mt = strings.SplitN(mt, ";", 2)[0]
-	return strings.Contains(mt, "spdx") || mt == "application/json"
 }


### PR DESCRIPTION
## Summary

Eight issues surfaced by the audit of the startup staleness check (`feature/sbom-version-check`, merged in #32), now fixed and covered by tests.

| # | Severity | Fix |
|---|---|---|
| **C1** | security | Signal handler loops instead of `signal.Reset` — the first ^C cancels the context so deferred RBAC cleanup runs; the second explicitly opts into a force-exit and prints the commands the user needs to clean up by hand. Previously, a double ^C bypassed `defer cleanupRBAC` entirely, leaking the SA, RBAC objects, and the on-disk kubeconfig with a live token. |
| **A5** | correctness | `digestForImage` returns `""` instead of `repoDigests[0]` when no prefix matches. On a multi-repo image ID (`docker tag` between registries), the previous fallback returned the digest of the wrong registry and false-prompted a pull from there. |
| **A2** | UX | The `LocalDigest` / `RemoteDigest` / `SameImage` block is now wrapped in `context.WithTimeout(ctx, 10s)`. A blackholing proxy can no longer wedge CLI startup before the Y/n prompt ever draws. |
| **A1** | correctness | `execClient.LocalDigest` filters stderr against the known not-found substrings (`no such image`, `image not known`, `manifest unknown`) instead of swallowing every non-zero exit as "no digest". Real daemon failures (socket down, permission denied) now surface as warnings. Also switched to `exec.CommandContext` so ^C interrupts. |
| **A3** | correctness | `LocalAgentVersions(ctx, runtime, img)` — `cfg.Runtime` threaded from `run()` through `maybePullIfStale()` and `printAgentVersionDiff()`. Hosts with both docker and podman no longer probe the wrong runtime. |
| **C3** | UX | 404 on the registry manifest endpoint is silently skipped. In-cluster registries with single-label hostnames (`registry/foo:tag`, routed to Docker Hub by docker convention) no longer emit "could not check for a newer image" noise on every startup. |
| **F1** | perf | The container-side probe runs only when `needsLocalProbe()` reports a gap in the SBOM data. Saves 1-2 s per startup on post-SBOM images, especially on Apple Silicon emulating linux/amd64. |
| **E1** | cleanup | ~50 lines of dead Referrers-API code removed — buildx pushes SBOMs as in-index attestation-manifests on GHCR, never as referrers. The attestation-manifest walk is now the single path. |

## Test plan

Unit + integration tests under `internal/container/`:

- [x] `client_test.go` — `digestForImage` (7 cases incl. the A5 regression), `parseImageRef`, `isImageNotFoundStderr`
- [x] `local_versions_test.go` — `parseAgentVersionLines` on noisy input
- [x] `registry_test.go` — an `httptest` TLS server serves a real buildx-style multi-arch image with an in-toto/SPDX attestation-manifest. Tests cover:
  - `FetchAgentVersions` end-to-end against the mock (claude/opencode via SBOM, copilot via OCI label)
  - `SameImage` index↔platform-child equivalence both directions, rejects unrelated digests
  - `fetchRegistryDigest` returns `("", nil)` on 404
  - `fetchRegistryDigest` honors `ctx.Done()` within 2 s against a hung server
- [x] `go test -race ./...` clean
- [x] `go vet ./...` clean
- [x] E2E live against `ghcr.io/qjoly/kpil:nightly` — `FetchAgentVersions` returns `claude=2.1.173, opencode=1.17.3, copilot=1.0.35` without pulling any layers
- [x] E2E `kpil --image :nightly` on an in-sync local image: no false-positive prompt, proceeds straight to cosign verify (SameImage handles the index↔per-platform mismatch)